### PR TITLE
Документ №1178962191 от 2020-03-19 Аверкиев П.А.

### DIFF
--- a/Controls/_list/SourceControl.ts
+++ b/Controls/_list/SourceControl.ts
@@ -129,9 +129,9 @@ export default class SourceControl extends Control<ISourceControlOptions, Record
 
     protected _beforeMount(options?: ISourceControlOptions, contexts?: object, receivedState?: RecordSet | void): Promise<RecordSet | void> | void {
         this._listSourceLoader = new ListSourceLoadingController({
-            keyProperty: this._options.keyProperty,
-            navigation: this._options.navigation,
-            source: this._options.source
+            keyProperty: options.keyProperty,
+            navigation: options.navigation,
+            source: options.source
         });
         // TODO implement external List/Grid sorting
         this._sorting = [];


### PR DESCRIPTION
http://online.sbis.ru/doc/ce694d76-e6e7-4266-a38b-593165597706  Регламент: Ошибка. Автор: Колесов В.А.
Описание: this._options = options
так не пишем.
Контрол сам себе опции не ставит. После маунта, они автоматически сохраняются в _options.
Если нужно обращаться к опциям в _beforeMount, то нужно брать options из аргументов.