### PR TITLE
Документ №1179340952 от 2020-05-20 Соловьев В.Г.

### DIFF
--- a/Controls/_breadcrumbs/HeadingPath/Back.wml
+++ b/Controls/_breadcrumbs/HeadingPath/Back.wml
@@ -18,7 +18,7 @@
    </ws:if>
    <ws:if data="{{ _options.showActionButton }}">
       <div class="controls-BreadCrumbsPath__backButtonArrow-container controls-BreadCrumbsPath__backButtonArrow-container_theme-{{_options.theme}}
-                  controls-background-{{backgroundStyle || 'default'}}_theme-{{_options.theme}}
+                  controls-background-{{_options.backgroundStyle || 'default'}}_theme-{{_options.theme}}
                   {{_options.readOnly ? ' controls-Path__backButtonArrow_readonly_theme-' + _options.theme}}"
            title="{[Подробнее]}"
            on:click="_onArrowClick()">

--- a/Controls/_breadcrumbs/HeadingPath/HeadingPath.wml
+++ b/Controls/_breadcrumbs/HeadingPath/HeadingPath.wml
@@ -2,6 +2,7 @@
     <div class="controls-BreadCrumbsPath__wrapper">
         <ws:if data="{{ _backButtonCaption && !_options.withoutBackButton }}">
             <Controls._breadcrumbs.HeadingPath.Back backButtonCaption="{{_backButtonCaption}}"
+                                               backgroundStyle="{{_options.backgroundStyle || _options.style}}"
                                                backButtonClass="{{_backButtonClass}}"
                                                counterCaption="{{ _getCounterCaption(_options.items) }}"
                                                showArrowOutsideOfBackButton="{{!_breadCrumbsItems && !_options.rootVisible}}"


### PR DESCRIPTION
https://online.sbis.ru/doc/7107c5af-bbe9-4dfd-bd1d-edb5e7b35de8  Фон  шеврона  неправильный
Настройки каталога Presto.  Фон у шеврона по ховеру должен быть того же цвета, что и фон, на котором располагается компонент.
Как повторить:
любая точка продаж / доп.настройки / настройки каталога
развернуть список разделов каталога / провалиться в любую папку
ФР:
Фон  шеврона  неправильный
ОР:
заливка равна фону, на котором располагается компонент
http://axure.tensor.ru/themes2/%D1%85%D0%BB%D0%B5%D0%B1%D0%BD%D1%8B%D0%B5_%D0%BA%D1%80%D0%BE%D1%88%D0%BA%D0%B8_0_2.html#OnLoadVariable=vdom&CSUM=1
Страница: Presto/СБИС
Логин: presto_admin Пароль: presto_admin123 
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36
Версия:
online-inside_20.3200 (ver 20.3200) - 62 (20.05.2020 - 14:10:00)
Platforma 20.3200 - 35 (20.05.2020 - 08:57:03)
WS 20.3200 - 28 (20.05.2020 - 07:55:00)
Types 20.3200 - 26 (20.05.2020 - 11:50:10)
CONTROLS 20.3200 - 33 (20.05.2020 - 11:40:11)
SDK 20.3200 - 124 (20.05.2020 - 12:48:04)
DISTRIBUTION: ext
GenerateDate: 20.05.2020 - 14:10:00
autoerror_sbislogs 20.05.2020