### PR TITLE
Документ №1179485706 от 2020-06-10 Митин А.Ю.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -114,6 +114,7 @@ export class Controller {
     private _editArrowVisibilityCallback: TEditArrowVisibilityCallback;
     private _editArrowAction: IItemAction;
     private _contextMenuConfig: IContextMenuConfig;
+    private _iconSize: TItemActionsSize;
 
     private _theme: string;
 
@@ -130,6 +131,7 @@ export class Controller {
         this._editArrowVisibilityCallback = options.editArrowVisibilityCallback || ((item: Model) => true);
         this._editArrowAction = options.editArrowAction;
         this._contextMenuConfig = options.contextMenuConfig;
+        this._iconSize = options.iconSize || DEFAULT_ACTION_SIZE;
         if (!options.itemActions ||
             !isEqual(this._commonItemActions, options.itemActions) ||
             this._itemActionsProperty !== options.itemActionsProperty ||
@@ -220,11 +222,12 @@ export class Controller {
             data: menuActions,
             keyProperty: 'id'
         });
+        const iconSize = (this._contextMenuConfig && this._contextMenuConfig.iconSize) || this._iconSize;
         const showHeader = parentAction !== null && parentAction !== undefined && !parentAction._isMenu;
         const headConfig = showHeader ? {
             caption: parentAction.title,
             icon: parentAction.icon,
-            iconSize: this._contextMenuConfig && this._contextMenuConfig.iconSize
+            iconSize
         } : null;
         const templateOptions: IMenuTemplateOptions = {
             source,
@@ -236,7 +239,8 @@ export class Controller {
             ...this._contextMenuConfig,
             root: parentAction && parentAction.id,
             showHeader,
-            headConfig
+            headConfig,
+            iconSize
         };
         return {
             opener,
@@ -381,7 +385,7 @@ export class Controller {
             toolbarVisibility: options.editingToolbarVisible,
             style: options.style,
             itemActionsClass: options.itemActionsClass,
-            size: options.iconSize || DEFAULT_ACTION_SIZE,
+            size: this._iconSize,
             itemActionsPosition: options.itemActionsPosition || DEFAULT_ACTION_POSITION,
             actionAlignment: options.actionAlignment || DEFAULT_ACTION_ALIGNMENT,
             actionCaptionPosition: options.actionCaptionPosition || DEFAULT_ACTION_CAPTION_POSITION

--- a/Controls/_itemActions/interface/IItemActions.ts
+++ b/Controls/_itemActions/interface/IItemActions.ts
@@ -206,10 +206,11 @@ export interface IMenuTemplateOptions extends IContextMenuConfig {
     closeButtonVisibility: boolean;
     root: number | string;
     showHeader: boolean;
+    iconSize: TItemActionsSize;
     headConfig?: {
         caption: string;
         icon: string;
-        iconSize: string;
+        iconSize: TItemActionsSize;
     };
 }
 

--- a/tests/ControlsUnit/itemActions/ItemActions.test.ts
+++ b/tests/ControlsUnit/itemActions/ItemActions.test.ts
@@ -200,7 +200,8 @@ describe('Controls/_itemActions/Controller', () => {
             editingToolbarVisible: options ? options.editingToolbarVisible : false,
             editArrowAction: options ? options.editArrowAction : false,
             editArrowVisibilityCallback: options ? options.editArrowVisibilityCallback: null,
-            contextMenuConfig: options ? options.contextMenuConfig: null
+            contextMenuConfig: options ? options.contextMenuConfig: null,
+            iconSize: options ? options.iconSize: 'm',
         };
     }
 
@@ -610,7 +611,7 @@ describe('Controls/_itemActions/Controller', () => {
         // T3.2. Если в метод parentAction - это кнопка открытия меню, то config.templateOptions.showHeader будет false
         it('should set config.templateOptions.showHeader \'false\' when parentAction is _isMenu', () => {
             const item3 = collection.getItemBySourceKey(3);
-            const actionsOf3 = collection.getItemBySourceKey(3).getActions();
+            const actionsOf3 = item3.getActions();
             const config = itemActionsController.prepareActionsMenuConfig(item3, clickEvent, actionsOf3.showed[actionsOf3.length - 1], null, false);
             assert.exists(config.templateOptions, 'Template options were not set when no isMenu parent passed');
             assert.isFalse(config.templateOptions.showHeader, 'showHeader should be false when isMenu parent passed');
@@ -671,7 +672,16 @@ describe('Controls/_itemActions/Controller', () => {
             assert.deepEqual(config.target.getBoundingClientRect(), target.getBoundingClientRect());
         });
 
-        // T3.5. Если в контрол был передан contextMenuConfig, его нужно объединять с templateOptions для Sticky.openPopup(menuConfig)
+        // T3.5. Если был установлен iconSize он должен примениться к templateOptions
+        it('should apply iconSize to templateOptions', () => {
+            const item3 = collection.getItemBySourceKey(3);
+            const actionsOf3 = item3.getActions();
+            const config = itemActionsController.prepareActionsMenuConfig(item3, clickEvent, actionsOf3.showed[actionsOf3.length - 1], null, false);
+            assert.exists(config.templateOptions, 'Template options were not set');
+            assert.equal(config.templateOptions.iconSize, 'm', 'iconSize from templateOptions has not been applied');
+        });
+
+        // T3.6. Если в контрол был передан contextMenuConfig, его нужно объединять с templateOptions для Sticky.openPopup(menuConfig)
         it ('should merge contextMenuConfig with templateOptions for popup config', () => {
             itemActionsController.update(initializeControllerOptions({
                 collection,
@@ -686,7 +696,7 @@ describe('Controls/_itemActions/Controller', () => {
             const config = itemActionsController.prepareActionsMenuConfig(item3, clickEvent, itemActions[3], null, false);
             assert.equal(config.templateOptions.groupProperty, 'title', 'groupProperty from contextMenuConfig has not been applied');
             assert.equal(config.templateOptions.headConfig.iconSize, 's', 'iconSize from contextMenuConfig has not been applied');
-        })
+        });
     });
 
     // см. этот же тест в Collection.test.ts


### PR DESCRIPTION
https://online.sbis.ru/doc/4f644199-23be-4d66-9c21-57254dcb8a91  (reg-chrome) 20.4100 VDOM controls - сместился текст в контекстном подменю
Ссылка:  http://test-autotest100.unix.tensor.ru:30000/Controls-demo/app/Controls-demo%2FList%2FItemActions
Как повторить:
- клик ПКМ по строке "Smartphones 3" верхнего списка
- открыть подменю
ОР (4000): http://test-autotest88.unix.tensor.ru:30000/Controls-demo/app/Controls-demo%2FList%2FItemActions
Ссылка на тест RegressionVDOMListBase.test_02_items_actions_inline_regression_opened_context_sub_menu  
autoerror_stanerror 10.06.20