### PR TITLE
Документ №1179514068 от 2020-06-16 Тихомиров А.А.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -180,7 +180,7 @@ export class Controller {
      * Получает последний swiped элемент
      */
     getSwipeItem(): IItemActionsItem {
-        return this._collection.find((item) => item.isSwiped());
+        return this._collection.find((item) => item.isSwiped() || item.isRightSwiped());
     }
 
     /**

--- a/tests/ControlsUnit/itemActions/ItemActions.test.ts
+++ b/tests/ControlsUnit/itemActions/ItemActions.test.ts
@@ -567,6 +567,28 @@ describe('Controls/_itemActions/Controller', () => {
             const item1 = collection.getItemBySourceKey(1);
             assert.isTrue(item1.isRightSwiped());
         });
+
+        // T2.12 При вызове getSwipeItem() контроллер должен возвращать true вне зависимости от типа анимации и направления свайпа.
+        it('method getSwipeItem() should return true despite of current animation type and direction', () => {
+            const item: CollectionItem<Record> = collection.getItemBySourceKey(1);
+            let swipedItem: CollectionItem<Record>;
+
+            itemActionsController.activateRightSwipe(1);
+            swipedItem = itemActionsController.getSwipeItem() as CollectionItem<Record>;
+            assert.equal(swipedItem, item, 'rightSwiped() item has not been found by getSwipeItem() method');
+            itemActionsController.deactivateSwipe();
+
+            swipedItem = itemActionsController.getSwipeItem() as CollectionItem<Record>;
+            assert.equal(swipedItem, null, 'Current swiped item has not been un-swiped');
+
+            itemActionsController.activateSwipe(1, 50);
+            swipedItem = itemActionsController.getSwipeItem() as CollectionItem<Record>;
+            assert.equal(swipedItem, item, 'swiped() item has not been found by getSwipeItem() method');
+            itemActionsController.deactivateSwipe();
+
+            swipedItem = itemActionsController.getSwipeItem() as CollectionItem<Record>;
+            assert.equal(swipedItem, null, 'Current swiped item has not been un-swiped');
+        });
     });
 
     describe('prepareActionsMenuConfig()', () => {


### PR DESCRIPTION
https://online.sbis.ru/doc/60c4cca0-232f-400c-a8bd-875960ec2675  iPad+safari. Перестает срабатывать свайп вправо если свайпать одну запись несколько раз
1. https://pre-test-online.sbis.ru/contacts/
2. свайп вправо по сообщению 3 раза, либо свайп по одному сообщению, потом дважды по другому
ФР: на 3й раз свайп не срабатывает
ОР: свайп работает не зависимо от кол-ва повторений