### PR TITLE
Документ №1179516089 от 2020-06-16 Матякин А.В.

### DIFF
--- a/Controls/_list/BaseControl/BaseControl.wml
+++ b/Controls/_list/BaseControl/BaseControl.wml
@@ -100,6 +100,7 @@
         <div name="topLoadTrigger"></div>
         <Controls.validate:Controller name="formController">
             <ws:partial
+                    attr:class="controls-itemActionsV_menu-{{_itemActionsMenuId ? 'shown' : 'hidden'}}"
                     name="{{name}}"
                     template="{{ _options.content }}"
                     scope="{{_options}}"

--- a/Controls/_list/EditInPlace/_Text.less
+++ b/Controls/_list/EditInPlace/_Text.less
@@ -8,7 +8,7 @@
    }
 }
 
-.ws-is-hover .controls-EditingTemplateText_active_theme-@{themeName} {
+.ws-is-hover .controls-itemActionsV_menu-hidden .controls-EditingTemplateText_active_theme-@{themeName} {
    background-color: @background-color_inputText;
 }
 

--- a/Controls/_list/EditInPlace/baseEditingTemplate.wml
+++ b/Controls/_list/EditInPlace/baseEditingTemplate.wml
@@ -8,7 +8,7 @@
                 {{enabled ? 'controls-EditingTemplateText_enabled_theme-' + theme}}
                 controls-EditingTemplateText_size_{{size ? size : 'default'}}_theme-{{theme}}
                 controls-EditingTemplateText_style_{{style ? style : 'default'}}
-                {{itemData.isActive() && !itemData.shouldDisplayActions() ? 'controls-EditingTemplateText_active_theme-' + theme}}">
+                {{itemData.isActive() ? 'controls-EditingTemplateText_active_theme-' + theme}}">
             <div class="controls-EditingTemplateText__inner">
                 <ws:partial template="{{ viewTemplate }}" />
             </div>

--- a/Controls/_listRender/Render/resources/EditInPlace/baseEditingTemplate.wml
+++ b/Controls/_listRender/Render/resources/EditInPlace/baseEditingTemplate.wml
@@ -7,7 +7,7 @@
             {{enabled ? 'controls-EditingTemplateText_enabled' + theme}}
             controls-EditingTemplateText_size_{{size ? size : 'default'}}_theme-{{theme}}
             controls-EditingTemplateText_style_{{style ? style : 'default'}}
-            {{itemData.isActive() && !itemData.shouldDisplayActions() ? 'controls-EditingTemplateText_active_theme-' + theme}}">
+            {{itemData.isActive() ? 'controls-EditingTemplateText_active_theme-' + theme}}">
             <div class="controls-EditingTemplateText__inner">
                 <ws:partial template="{{ viewTemplate }}"/>
             </div>


### PR DESCRIPTION
https://online.sbis.ru/doc/82554846-3708-44ae-85a0-0bd1cb702c45 Не открывается меню по ховеру в реестре каталога если включен режим редактирования
Как повторить: 
1.Зайти на пре тест кабинет123/кабинет1234
2.Перейти в бизнес-каталог
3.В пмо включить режим реадктирвоания в реестре
4.Навести на товар и нажать на стрелку открытия команд по ховеру
ФР: 
Ошибка в консоль ничего не открылось
ОР: 
Нет ошибок, консоль открылась
Страница: Каталог и цены/СБИС
Логин: кабинет123 Пароль: кабинет123 
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4168.3 Safari/537.36
Версия:
online-inside_20.4100 (ver 20.4100) - 757 (16.06.2020 - 08:34:09)
Platforma 20.4100 - 60 (16.06.2020 - 06:42:00)
WS 20.4100 - 52 (16.06.2020 - 07:20:00)
Types 20.4100 - 44 (15.06.2020 - 20:37:13)
CONTROLS 20.4100 - 59 (16.06.2020 - 06:14:00)
SDK 20.4100 - 236 (16.06.2020 - 08:18:07)
DISTRIBUTION: inside
GenerateDate: 16.06.2020 - 08:34:09
autoerror_sbislogs 16.06.2020