### PR TITLE
Документ №1179498392 от 2020-06-11 Акимова И.С.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1138,7 +1138,7 @@ var
                 });
             }
 
-            if (!resultsColumn.column.isActionCell && (columnIndex > hasMultiSelect ? 1 : 0)) {
+            if (!resultsColumn.column?.isActionCell && (columnIndex > hasMultiSelect ? 1 : 0)) {
                 const columnSeparatorSize = _private.getSeparatorForColumn(
                     this._options.columns,
                     columnIndex - (hasMultiSelect ? 1 : 0),
@@ -1189,7 +1189,7 @@ var
                         const format = results.getFormat();
                         const fieldIndex = format.getIndexByValue('name', resultsColumn.column.displayProperty);
                         resultsColumn.resultsFormat = fieldIndex !== -1 ? format.at(fieldIndex).getType() : undefined;
-            }
+                    }
                 }
 
                 resultsColumn.showDefaultResultTemplate = !!resultsColumn.resultsFormat;

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -1723,6 +1723,13 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             delete gridViewModel._options.columns[1].columnSeparatorSize;
          });
 
+         // Иногда таблица инициализируется без колонок. Тогда метод getCurrentResultsColumn не должен вызывать ошибок.
+         it('should calculate params for resultColumn when grid initialized without columns', () => {
+            // gridViewModel = new gridMod.GridViewModel({ ...cfg, multiSelectVisibility: 'hidden', columns: [] });
+            // const currentResultColumn = gridViewModel.getCurrentResultsColumn();
+            // assert.deepEqual(currentResultColumn.column, undefined);
+         });
+
          it('first header cell with breadcrumbs should renders from first column', function () {
               const originBreadcrumbsCell = gridViewModel._headerRows[0][1];
               gridViewModel._headerRows[0][1] = {

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -1725,9 +1725,9 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
 
          // Иногда таблица инициализируется без колонок. Тогда метод getCurrentResultsColumn не должен вызывать ошибок.
          it('should calculate params for resultColumn when grid initialized without columns', () => {
-            // gridViewModel = new gridMod.GridViewModel({ ...cfg, multiSelectVisibility: 'hidden', columns: [] });
-            // const currentResultColumn = gridViewModel.getCurrentResultsColumn();
-            // assert.deepEqual(currentResultColumn.column, undefined);
+            const newGridViewModel = new gridMod.GridViewModel({ ...cfg, multiSelectVisibility: 'hidden', columns: [] });
+            const currentResultColumn = newGridViewModel.getCurrentResultsColumn();
+            assert.deepEqual(currentResultColumn.column, undefined);
          });
 
          it('first header cell with breadcrumbs should renders from first column', function () {


### PR DESCRIPTION
https://online.sbis.ru/doc/c494ec15-09d2-471a-88dc-f85e5ee939f8 Банк/Касса: Ошибка в консоли при переходе в реестр р/счетов
Как повторить:
Учет/Деньги/Банк
Перейти на вкладку Р/счета
ФР:
Ошибка в консоли:
EMPLATE ERROR:  Failed to generate html IN "Controls/_grid/layout/grid/Results"
Stack: TypeError: Cannot read property 'isActionCell' of undefined
ОР:
Переход в реестр без ошибок.
Страница: Расчетные счета/СБИС
Логин: деньгиобщ Пароль:   ДеньгиОбщ1234
UserAgent: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36
Версия:
online-inside_20.4100 (ver 20.4100) - 704 (11.06.2020 - 12:06:48)
Platforma 20.4100 - 39 (11.06.2020 - 10:27:48)
WS 20.4100 - 34 (11.06.2020 - 09:20:15)
Types 20.4100 - 31 (11.06.2020 - 07:37:00)
CONTROLS 20.4100 - 42 (11.06.2020 - 09:25:00)
SDK 20.4100 - 160 (11.06.2020 - 11:48:55)
DISTRIBUTION: ext
GenerateDate: 11.06.2020 - 12:06:48
StableSDK
autoerror_sbislogs 11.06.2020