### PR TITLE
Документ №1179538432 от 2020-06-18 Едренкин А.С.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -227,7 +227,7 @@ export class Controller {
             data: menuActions,
             keyProperty: 'id'
         });
-        const iconSize = (this._contextMenuConfig && this._contextMenuConfig.iconSize) || this._iconSize;
+        const iconSize = (this._contextMenuConfig && this._contextMenuConfig.iconSize) || DEFAULT_ACTION_SIZE;
         const showHeader = parentAction !== null && parentAction !== undefined && !parentAction._isMenu;
         const headConfig = showHeader ? {
             caption: parentAction.title,

--- a/tests/ControlsUnit/itemActions/ItemActions.test.ts
+++ b/tests/ControlsUnit/itemActions/ItemActions.test.ts
@@ -720,6 +720,22 @@ describe('Controls/_itemActions/Controller', () => {
             assert.equal(config.templateOptions.headConfig.iconSize, 's', 'iconSize from contextMenuConfig has not been applied');
         });
 
+        // T3.6.1. Если в контрол был передан contextMenuConfig без IconSize, нужно применять размер иконки по умолчанию
+        it('should use default IconSize when contextMenuConfig does not contain iconSize property', () => {
+            itemActionsController.update(initializeControllerOptions({
+                collection,
+                itemActions,
+                theme: 'default',
+                iconSize: 's',
+                contextMenuConfig: {
+                    groupProperty: 'title'
+                }
+            }));
+            const item3 = collection.getItemBySourceKey(3);
+            const config = itemActionsController.prepareActionsMenuConfig(item3, clickEvent, itemActions[3], null, false);
+            assert.equal(config.templateOptions.iconSize, 'm', 'default iconSize has not been applied');
+        });
+
         // T3.7. Для меню не нужно считать controls-itemActionsV__action_icon_theme-default
         it('should not set "controls-itemActionsV__action_icon_theme-default" CSS class for menu item actions icons', () => {
             const item3 = collection.getItemBySourceKey(3);


### PR DESCRIPTION
https://online.sbis.ru/doc/70500028-5bf6-49b1-8583-c41f03e917ee  Уменьшились иконки опций по ховеру 16х16 рх вместо 24х25 рх
1. pre-test-online.sbis.ru (PG/pneumo123)
2. Перейти в чаты/диалог, раскрыть опции по ховеру сообщения
ФР: Иконки опций по ховеру 16х16
ОР: Иконки опций по ховеру 24х25