### PR TITLE
Документ №1179592697 от 2020-06-26 Горбунова М.В.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -18,7 +18,7 @@ import {
     TItemActionsPosition,
     TActionCaptionPosition,
     TEditArrowVisibilityCallback,
-    TActionDisplayMode
+    TActionDisplayMode, TMenuButtonVisibility
 } from './interface/IItemActions';
 import { verticalMeasurer } from './measurers/VerticalMeasurer';
 import { horizontalMeasurer } from './measurers/HorizontalMeasurer';
@@ -450,6 +450,7 @@ export class Controller {
         if (!item) {
             return;
         }
+        const menuButtonVisibility = this._getSwipeMenuButtonVisibility(this._contextMenuConfig);
         this._actionsHeight = actionsContainerHeight;
         let actions = item.getActions().all;
         const actionsTemplateConfig = this._collection.getActionsTemplateConfig();
@@ -465,7 +466,8 @@ export class Controller {
             actions,
             actionsTemplateConfig.actionAlignment,
             actionsContainerHeight,
-            actionsTemplateConfig.actionCaptionPosition
+            actionsTemplateConfig.actionCaptionPosition,
+            menuButtonVisibility
         );
 
         if (
@@ -477,7 +479,8 @@ export class Controller {
                 actions,
                 actionsTemplateConfig.actionAlignment,
                 actionsContainerHeight,
-                actionsTemplateConfig.actionCaptionPosition
+                actionsTemplateConfig.actionCaptionPosition,
+                menuButtonVisibility
             );
         }
         this._collection.setActionsTemplateConfig(actionsTemplateConfig);
@@ -492,6 +495,16 @@ export class Controller {
         }
 
         this._collection.setSwipeConfig(swipeConfig);
+    }
+
+    /**
+     * Возвращает значение видимоси кнопки "Ещё" для свайпа
+     * @param contextMenuConfig
+     * @private
+     */
+    private _getSwipeMenuButtonVisibility(contextMenuConfig): TMenuButtonVisibility {
+        return (contextMenuConfig && (contextMenuConfig.footerTemplate
+            || contextMenuConfig.headerTemplate)) ? 'visible' : 'adaptive';
     }
 
     /**
@@ -649,13 +662,15 @@ export class Controller {
         actions: IItemAction[],
         actionAlignment: string,
         actionsContainerHeight: number,
-        actionCaptionPosition: 'right'|'bottom'|'none'
+        actionCaptionPosition: TActionCaptionPosition,
+        menuButtonVisibility?: TMenuButtonVisibility
     ): ISwipeConfig {
         const measurer = actionAlignment === 'vertical' ? verticalMeasurer : horizontalMeasurer;
         const config: ISwipeConfig = measurer.getSwipeConfig(
             actions,
             actionsContainerHeight,
-            actionCaptionPosition
+            actionCaptionPosition,
+            menuButtonVisibility
         );
         config.needTitle = measurer.needTitle;
         config.needIcon = measurer.needIcon;

--- a/Controls/_itemActions/interface/IItemActions.ts
+++ b/Controls/_itemActions/interface/IItemActions.ts
@@ -71,6 +71,14 @@ export type TItemActionsPosition = 'inside'|'outside'|'custom';
 export type TItemActionsSize = 'm'|'s';
 
 /**
+ * @cfg {string} TItemActionsSize
+ * Видимость кнопки "Ещё" в свайпе
+ * @variant visible - кнопка видима в любом случае
+ * @variant adaptive - Расчёт происходит от количесива элементов в свайпе
+ */
+export type TMenuButtonVisibility = 'visible'|'adaptive';
+
+/**
  * Configuration object for a button which will be shown when the user hovers over a list item.
  * TODO duplicated from IList
  */

--- a/tests/ControlsUnit/itemActions/Controller.test.ts
+++ b/tests/ControlsUnit/itemActions/Controller.test.ts
@@ -504,6 +504,55 @@ describe('Controls/_itemActions/Controller', () => {
             assert.isUndefined(config.twoColumns);
         });
 
+        // T2.3.1. Если при инициализации в конфиге контекстного меню передан footerTemplate нужно принудительно показывать кнопку "ещё"
+        it('should add menu button for horizontal swipe when contextMenu.footerTemplate is passed', () => {
+            itemActionsController.update(initializeControllerOptions({
+                collection,
+                itemActions: horizontalOnlyItemActions,
+                theme: 'default',
+                actionAlignment: 'horizontal',
+                contextMenuConfig: {
+                    footerTemplate: 'template'
+                }
+            }));
+            itemActionsController.activateSwipe(3, 50);
+            const config = collection.getSwipeConfig();
+            assert.exists(config, 'Swipe activation should make configuration');
+            assert.isTrue(config.itemActions.showed[config.itemActions.showed.length -1]._isMenu, 'menu button was not added');
+        });
+
+        // T2.3.2. Если при инициализации в конфиге контекстного меню передан headerTemplate нужно принудительно показывать кнопку "ещё"
+        it('should add menu button for horizontal swipe when contextMenu.headerTemplate is passed', () => {
+            itemActionsController.update(initializeControllerOptions({
+                collection,
+                itemActions: horizontalOnlyItemActions,
+                theme: 'default',
+                actionAlignment: 'horizontal',
+                contextMenuConfig: {
+                    headerTemplate: 'template'
+                }
+            }));
+            itemActionsController.activateSwipe(3, 50);
+            const config = collection.getSwipeConfig();
+            assert.exists(config, 'Swipe activation should make configuration');
+            assert.isTrue(config.itemActions.showed[config.itemActions.showed.length -1]._isMenu, 'menu button was not added');
+        });
+
+        // T2.3.2. кнопка "Ещё" в горизонтальном свайпе не будет показана, если записей меньше 4
+        // (этот тест работает до тех пор, пока мы не сделаем расчёт горизонтальных опций от их ширины, см. horizontalMeasurer)
+        it('should add menu button for horizontal swipe when contextMenu.headerTemplate is passed', () => {
+            itemActionsController.update(initializeControllerOptions({
+                collection,
+                itemActions: horizontalOnlyItemActions,
+                theme: 'default',
+                actionAlignment: 'horizontal'
+            }));
+            itemActionsController.activateSwipe(3, 50);
+            const config = collection.getSwipeConfig();
+            assert.exists(config, 'Swipe activation should make configuration');
+            assert.notExists(config.itemActions.showed[config.itemActions.showed.length -1]._isMenu, 'menu button was added');
+        });
+
         // T2.3. В зависимости от actionAlignment, для получения конфигурации используется правильный measurer
         // T2.5. Конфигурация для Swipe происходит с установкой twoColumnsActions, если measurer вернул в конфиг twoColumns
         it('should use vertical measurer when actionAlignment=\'vertical\'', () => {


### PR DESCRIPTION
https://online.sbis.ru/doc/7c04fc9d-1359-48ae-9a3d-34d20fa9ae78  Ipad
Не появляется список для добавления пометок и папок в доп.меню у Карточки контрагента
(нет трех точек для открытия меню)
Как повторить:
1. Бизнес -> Продажи CRM -> Клиенты
2. Свайп влево у Карточки контрагента
ФР: есть опции только Закрепить и Удалить
ОР: при открытии доп.меню сразу появляется список папок и тегов для добавления
подключение к ipad  возможно через программу TightVNC: хост usd-macprog8, пароль: 1234, пользователь prog/prog, по окончанию работ выходите из под пользователя!