### PR TITLE
Документ №1179527772 от 2020-06-17 Иванов А.В.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -102,7 +102,7 @@ export interface IItemActionsControllerOptions {
     /**
      * Редактируемая запись
      */
-    editingItem: CollectionItem<Model>
+    editingItem: IItemActionsItem
 }
 
 /**
@@ -326,7 +326,7 @@ export class Controller {
      *  необходимо будет вычистить return методов update() и _updateItemActions(). Эти методы будут void
      * @private
      */
-    private _updateItemActions(editingItem?: CollectionItem<Model>): Array<number | string> {
+    private _updateItemActions(editingItem?: IItemActionsItem): Array<number | string> {
         let hasChanges = false;
         const changedItemsIds: Array<number | string> = [];
         const assignActionsOnItem = (item) => {

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -2067,10 +2067,16 @@ const _private = {
         if (self.__error || !self._listViewModel) {
             return;
         }
+        const editingConfig = self._listViewModel.getEditingConfig();
+        // Если нет опций записи, проперти, и тулбар для редактируемой записи выставлен в false, то не надо
+        // инициализировать контроллер
+        if (!options.itemActions && !options.itemActionsProperty && !editingConfig?.toolbarVisibility) {
+            return;
+        }
         if (!self._itemActionsController) {
             self._itemActionsController = new ItemActionsController();
         }
-        const editingConfig = self._listViewModel.getEditingConfig();
+
         const editingItemData = self._listViewModel.getEditingItemData && self._listViewModel.getEditingItemData();
         const isActionsAssigned = self._listViewModel.isActionsAssigned();
         let editArrowAction: IItemAction;

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -3000,13 +3000,7 @@ define([
                      title: '123'
                   }
                ],
-               viewModelConstructor: lists.ListViewModel,
-               navigation: {
-                  source: 'page',
-                  sourceConfig: {
-                     pageSize: 6
-                  }
-               }
+               viewModelConstructor: lists.ListViewModel
             };
             isActionsUpdated = false;
             stubItemActionsController = sinon.stub(itemActions.Controller.prototype, 'update').callsFake(() => {

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -15,9 +15,9 @@ define([
    'Types/entity',
    'Controls/popup',
    'Controls/listDragNDrop',
-   'Controls/listRender',
+   'Controls/itemActions',
    'Core/polyfill/PromiseAPIDeferred'
-], function(sourceLib, collection, lists, treeGrid, grid, tUtil, cDeferred, cInstance, Env, clone, entity, popup, listDragNDrop, listRender) {
+], function(sourceLib, collection, lists, treeGrid, grid, tUtil, cDeferred, cInstance, Env, clone, entity, popup, listDragNDrop, itemActions) {
    describe('Controls.List.BaseControl', function() {
       var data, result, source, rs, sandbox;
       beforeEach(function() {
@@ -2919,14 +2919,14 @@ define([
          assert.isTrue(item.isSelected());
       });
 
-      describe('updateItemActions', function() {
+      describe('initializing of sourceController', function() {
          var source = new sourceLib.Memory({
                keyProperty: 'id',
                data: data
             }),
             cfg = {
                editingConfig: {
-                  item: new entity.Model({rawData: { id: 1 }})
+                  item: new entity.Model({rawData: {id: 1}})
                },
                viewName: 'Controls/List/ListView',
                source: source,
@@ -2949,15 +2949,11 @@ define([
 
          baseControl.saveOptions(cfg);
          baseControl._beforeMount(cfg);
-         var actionsUpdateCount = 0;
          baseControl._container = {
             clientHeight: 100,
-            getBoundingClientRect: () => ({ y: 0 })
+            getBoundingClientRect: () => ({y: 0})
          };
 
-         afterEach(() => {
-            actionsUpdateCount = 0;
-         });
           it('update sourceController onListChange', function() {
               sandbox.stub(lists.BaseControl._private, 'prepareFooter');
 
@@ -2966,17 +2962,107 @@ define([
 
               sinon.assert.calledOnce(lists.BaseControl._private.prepareFooter);
           });
+      });
+
+      describe('calling updateItemActions method with different params', function() {
+         let stubItemActionsController;
+         let source;
+         let isActionsUpdated;
+         let cfg;
+         let baseControl;
+
+         const initTestBaseControl = (config) => {
+            const _baseControl = new lists.BaseControl(config);
+            _baseControl.saveOptions(config);
+            _baseControl._beforeMount(config);
+            _baseControl._container = {
+               clientHeight: 100,
+               getBoundingClientRect: () => ({ y: 0 })
+            };
+            return _baseControl;
+         };
+
+         beforeEach(() => {
+            source = new sourceLib.Memory({
+               keyProperty: 'id',
+               data: data
+            });
+            cfg = {
+               editingConfig: {
+                  item: new entity.Model({rawData: { id: 1 }})
+               },
+               viewName: 'Controls/List/ListView',
+               source: source,
+               keyProperty: 'id',
+               itemActions: [
+                  {
+                     id: 1,
+                     title: '123'
+                  }
+               ],
+               viewModelConstructor: lists.ListViewModel,
+               navigation: {
+                  source: 'page',
+                  sourceConfig: {
+                     pageSize: 6
+                  }
+               }
+            };
+            isActionsUpdated = false;
+            stubItemActionsController = sinon.stub(itemActions.Controller.prototype, 'update').callsFake(() => {
+               isActionsUpdated = true;
+               return [];
+            });
+         });
+         afterEach(() => {
+            stubItemActionsController.restore();
+         });
+
          it('control in error state, should not call update', function() {
+            baseControl = initTestBaseControl(cfg);
             baseControl.__error = true;
             lists.BaseControl._private.updateItemActions(baseControl, baseControl._options);
-            assert.equal(actionsUpdateCount, 0);
+            assert.isFalse(isActionsUpdated);
             baseControl.__error = false;
          });
          it('without listViewModel should not call update', function() {
+            baseControl = initTestBaseControl(cfg);
             baseControl._listViewModel = null;
             lists.BaseControl._private.updateItemActions(baseControl, baseControl._options);
-            assert.equal(actionsUpdateCount, 0);
+            assert.isFalse(isActionsUpdated);
             baseControl._beforeMount(cfg);
+         });
+
+         // Если нет опций записи, проперти, и тулбар для редактируемой записи выставлен в false, то не надо
+         // инициализировать контроллер
+         it('should not initialize controller when there are no itemActions, no itemActionsProperty and toolbarVisibility is false', () => {
+            baseControl = initTestBaseControl({ ...cfg, itemActions: null });
+            lists.BaseControl._private.updateItemActions(baseControl, baseControl._options);
+            assert.isFalse(isActionsUpdated);
+         });
+
+         it('should initialize controller when itemActions are set, but, there are no itemActionsProperty and toolbarVisibility is false', () => {
+            baseControl = initTestBaseControl({ ...cfg });
+            lists.BaseControl._private.updateItemActions(baseControl, baseControl._options);
+            assert.isTrue(isActionsUpdated);
+         });
+
+         it('should initialize controller when itemActionsProperty is set, but, there are no itemActions and toolbarVisibility is false', () => {
+            baseControl = initTestBaseControl({ ...cfg, itemActions: null, itemActionsProperty: 'myActions' });
+            lists.BaseControl._private.updateItemActions(baseControl, baseControl._options);
+            assert.isTrue(isActionsUpdated);
+         });
+
+         it('should initialize controller when toolbarVisibility is true, but, there are no itemActions and no itemActionsProperty', () => {
+            baseControl = initTestBaseControl({
+               ...cfg,
+               itemActions: null,
+               editingConfig: {
+                  toolbarVisibility: true
+               }
+            });
+            lists.BaseControl._private.updateItemActions(baseControl, baseControl._options);
+            assert.isTrue(isActionsUpdated);
          });
       });
       describe('resetScrollAfterReload', function() {


### PR DESCRIPTION
https://online.sbis.ru/doc/17f7f0cf-590a-4c63-b041-19fc7fd4c4ff  При отсутствии операций над элементом списка в режиме редактирования по месту всё равно отображается контейнер. 
Мне нужно убрать серый фон, я достиг этого без подлома стилей, но контейнер для itemActions остался. (см. поле руководитель)
Страница: СБИС
Логин: Демо_тензор Пароль:   Демо123
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36
Версия:
online-inside_20.4100 (ver 20.4100) - 739 (14.06.2020 - 18:00:00)
Platforma 20.4100 - 50 (14.06.2020 - 06:42:00)
WS 20.4100 - 43 (14.06.2020 - 09:20:10)
Types 20.4100 - 38 (14.06.2020 - 07:37:00)
CONTROLS 20.4100 - 51 (14.06.2020 - 06:14:00)
SDK 20.4100 - 201 (14.06.2020 - 09:56:45)
DISTRIBUTION: inside
GenerateDate: 14.06.2020 - 18:00:00
autoerror_sbislogs 6/17/2020