### PR TITLE
Документ №1179652323 от 2020-07-06 Константинова И.Ю.

### DIFF
--- a/Controls/_grid/layout/grid/_Grid.less
+++ b/Controls/_grid/layout/grid/_Grid.less
@@ -540,6 +540,7 @@
    min-width: 0; //https://css-tricks.com/flexbox-truncated-text/
    flex-shrink: 1;
    box-sizing: border-box;
+   height: 100%;
 }
 
 .controls-Grid__row-cell_cursor-default {
@@ -564,7 +565,7 @@
    // иначе все position: absolute элементы внутри position: sticky
    // начинают сроиться относительно родителя уровнем выше
    // translateZ лечит высоту, но ломает ширину внутри sticky контейнер
-   // translateY правит обе проблемы, с ним нормализуетя и высота и ширина, поэтому используем его   
+   // translateY правит обе проблемы, с ним нормализуетя и высота и ширина, поэтому используем его
    transform: translateY(0);
 }
 

--- a/Controls/_grid/layout/grid/_Grid.less
+++ b/Controls/_grid/layout/grid/_Grid.less
@@ -11,7 +11,7 @@
       display: none;
    }
 
-   
+
    .controls-Grid__row-cell__ladder-content_hiddenForLadder_show-on-drag,
    .controls-Grid__row-cell__content_ladderHeader {
       visibility: visible;
@@ -176,6 +176,7 @@
    flex-grow: 1;
    box-sizing: border-box;
    max-width: 100%;
+   height: 100%;
 }
 
 .controls-Grid__itemAction.controls-itemActionsV_outside_theme-@{themeName} {


### PR DESCRIPTION
https://online.sbis.ru/doc/2f994b36-59aa-49ba-8c49-d1a6c4e9084f  Бета-версия. НДС_Неправильное выделение строки по ховеру в реестре разделов 8-12 после закрытия формы редактирования фактуры
Шаги:
1. В бета-версии хрома:  fix-online.sbis.ru (сверкандс / сверкандс123)
2. Перейти
https://fix-online.sbis.ru/complect/67112/
или Отчетность - Создать - НД по НДС - добавить раздел 8 - добавить сведение - сохранить
3. Раздел 8 - кликнуть на фактуру (строку таблицы) - закрыть форму редактирования фактуры
4. Навести фокус на строку
ФР: Выделилась большая область - которая занята была при открытой формы редактирования
ОР: Выделилась только строка с записью, как в актуальной версии
Версия:
online-inside_20.4110 (ver 20.4110) - 46 (06.07.2020 - 13:55:41)
Platforma 20.4100 - 131 (06.07.2020 - 11:51:39)
WS 20.4100 - 107 (06.07.2020 - 11:52:58)
Types 20.4100 - 76 (25.06.2020 - 01:21:52)
CONTROLS 20.4100 - 161 (06.07.2020 - 11:52:53)
SDK 20.4100 - 521 (06.07.2020 - 13:42:46)
DISTRIBUTION: ext
GenerateDate: 06.07.2020 - 13:55:41