### PR TITLE
Документ №1179722653 от 2020-07-16 Антонов Д.Н.

### DIFF
--- a/Controls/_grid/layout/grid/_Grid.less
+++ b/Controls/_grid/layout/grid/_Grid.less
@@ -287,8 +287,7 @@
    }
 
 }
-.ws-is-hover .controls-BaseControl_showActions .controls-Grid__row:hover,
-.ws-is-touch .controls-GridView__item_active_theme-@{themeName} {
+.ws-is-hover .controls-BaseControl_showActions .controls-Grid__row:hover {
    .controls-Grid__editArrow-blur_theme-@{themeName},
    .controls-Grid__editArrow-wrapper_theme-@{themeName} {
       visibility: visible;

--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -519,7 +519,7 @@ export class Controller {
      * @param actions
      * @private
      */
-    private _addEditArrow(actions: IItemAction[]) {
+    private _addEditArrow(actions: IItemAction[]): void {
         if (!actions.find((action) => action.id === 'view')) {
             actions.unshift(this._fixShownActionOptions(this._editArrowAction));
         }

--- a/Controls/_itemActions/interface/IItemActions.ts
+++ b/Controls/_itemActions/interface/IItemActions.ts
@@ -150,7 +150,7 @@ export interface IItemAction {
 /**
  * Расширенный интерфейс IItemAction с полями для использования в шаблоне
  */
-interface IShownItemAction extends IItemAction {
+export interface IShownItemAction extends IItemAction {
     /**
      * Показывать текст операции
      */

--- a/tests/ControlsUnit/itemActions/Controller.test.ts
+++ b/tests/ControlsUnit/itemActions/Controller.test.ts
@@ -661,7 +661,7 @@ describe('Controls/_itemActions/Controller', () => {
         });
 
         // T2.10. При свайпе добавляется editArrow в набор операций, вызывается editArrowVisibilityCallback.
-        it('should call add editArrow for every item action when necessary', () => {
+        it('should add editArrow for every item action when necessary', () => {
             const editArrowAction: IItemAction = {
                 id: 'view',
                 icon: '',
@@ -686,6 +686,28 @@ describe('Controls/_itemActions/Controller', () => {
             assert.isTrue(recordWithCorrectType, 'editArrowVisibilityCallback should be called with Model type argument');
             assert.equal(config.itemActions.showed[0].id, 'view', 'First action should be \'editArrow\'');
         });
+
+        //T2.10.1 При свайпе editArrow добавляется в набор операций также и при itemActionsPosition: 'outside'
+        it('should add editArrow when itemActionsPosition: \'outside\'', () => {
+            const editArrowAction: IItemAction = {
+                id: 'view',
+                icon: '',
+                showType: TItemActionShowType.TOOLBAR,
+            };
+            const editArrowVisibilityCallback = () => true;
+            itemActionsController.update(initializeControllerOptions({
+                collection,
+                itemActions,
+                theme: 'default',
+                editArrowAction,
+                itemActionsPosition: 'outside',
+                editArrowVisibilityCallback
+            }));
+            itemActionsController.activateSwipe(1, 50);
+            const item = itemActionsController.getSwipeItem();
+            assert.exists(item, 'Swipe activation should set swiped item');
+            assert.equal(item.getActions().showed[0].id, 'view', 'First action should be \'editArrow\'');
+        })
 
         // T2.11 При вызове activateRightSwipe нужно устанавливать в коллекцию анимацию right-swiped и isSwiped
         it('should right-swipe item on activateRightSwipe() method', () => {


### PR DESCRIPTION
https://online.sbis.ru/doc/11d279de-c7aa-4bc7-8472-1d109565d45f  Клиенты CRM. Клиенты в Салоне/Presto/Магазине. Реестр клиентов в "Салоне"
Вертикальная полоса справа от названия папки при вызове ховера свайпом влево в реестре клиентов на safari(ipad)
Шаги воспроизведения
1. Через safari(ipad) зайти на https://fix-online.sbis.ru/
    (Демо_тензор/Демо123)
2. Салон -> Клиенты
3. Свайп влево по папке
Фактический результат
Справа от названия папки вертикальная полоса
Ожидаемый результат
Вертикальная полоса справа от названия папки отсутствует
online-inside_20.4119 (ver 20.4119) - 106 (16.07.2020 - 00:19:18)
Platforma 20.4100 - 144 (15.07.2020 - 19:09:32)
WS 20.4100 - 116 (15.07.2020 - 20:02:44)
Types 20.4100 - 76 (25.06.2020 - 01:21:52)
CONTROLS 20.4100 - 194 (15.07.2020 - 20:11:32)
SDK 20.4100 - 566 (15.07.2020 - 21:15:50)
DISTRIBUTION: inside
GenerateDate: 16.07.2020 - 00:19:18