### PR TITLE
Документ №1179802249 от 2020-07-28 Вялов М.С.

### DIFF
--- a/Controls-demo/Explorer/resources/CustomItemContent.wml
+++ b/Controls-demo/Explorer/resources/CustomItemContent.wml
@@ -1,4 +1,4 @@
-<div class="controls-TileView__imageWrapper js-controls-SwipeControl__actionsContainer">
+<div class="controls-TileView__imageWrapper js-controls-ItemActions__measurementContainer">
    <div class="{{hasTitle ? 'controls-TileView__resizer_theme-' + itemData.theme}}" style="{{'padding-top: ' + (itemData.itemsHeight / width) * 100 + '%;'}}"></div>
    <img class="controls-TileView__image demo-Explorer__image" src="{{itemData.item[itemData.imageProperty]}}"/>
    <ws:partial if="{{itemData.isSwiped && itemData.drawActions}}"

--- a/Controls/_display/CollectionItem.ts
+++ b/Controls/_display/CollectionItem.ts
@@ -417,7 +417,7 @@ export default class CollectionItem<T> extends mixin<
         return `controls-ListView__itemV
             controls-ListView__item_default
             controls-ListView__item_showActions
-            js-controls-SwipeControl__actionsContainer
+            js-controls-Swipe__measurementContainer
             ${templateHighlightOnHover ? 'controls-ListView__item_highlightOnHover_default_theme_default' : ''}
             ${this.isEditing() ? ` controls-ListView__item_editing_theme-${theme}` : ''}
             ${this.isDragged() ? ` controls-ListView__item_dragging_theme-${theme}` : ''}`;

--- a/Controls/_display/GridColumn.ts
+++ b/Controls/_display/GridColumn.ts
@@ -46,7 +46,7 @@ export default class GridColumn<T> extends mixin<
 
     getCellClasses(templateHighlightOnHover: boolean): string {
         // GridViewModel -> getItemColumnCellClasses
-        let classes = 'controls-Grid__row-cell controls-Grid__row-cell_theme-default js-controls-SwipeControl__actionsContainer';
+        let classes = 'controls-Grid__row-cell controls-Grid__row-cell_theme-default js-controls-Swipe__measurementContainer';
 
         // if !checkBoxCell
         classes += ' controls-Grid__cell_fit';

--- a/Controls/_display/TileCollectionItem.ts
+++ b/Controls/_display/TileCollectionItem.ts
@@ -122,7 +122,7 @@ export default class TileCollectionItem<T> extends CollectionItem<T> {
 
     getTileContentClasses(templateShadowVisibility?: string, templateMarker?: boolean, theme?:string): string {
         const theme = `_theme-${theme}`;
-        let classes = `controls-TileView__itemContent controls-TileView__itemContent${theme} js-controls-SwipeControl__actionsContainer`;
+        let classes = `controls-TileView__itemContent controls-TileView__itemContent${theme} js-controls-Swipe__measurementContainer`;
         classes += ` controls-ListView__item_shadow_${this.getShadowVisibility(templateShadowVisibility)}${theme}`;
         if (this.isActive()) {
             classes += ` controls-TileView__item_active${theme}`;

--- a/Controls/_grid/layout/grid/Item.wml
+++ b/Controls/_grid/layout/grid/Item.wml
@@ -79,7 +79,7 @@
 
 <ws:template name="STICKY_LADDER_HEADER">
    <ws:if data="{{itemData.stickyLadder[stickyProperty].headingStyle && currentColumn.hiddenForLadder}}">
-      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-SwipeControl__actionsContainer"
+      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer"
            attr:key="{{itemData.key + stickyProperty + '_sticky_ladder'}}"
            attr:style="{{itemData.stickyLadder[stickyProperty].headingStyle}}">
 
@@ -111,17 +111,17 @@
    <!-- Данный выводятся в зафиксированной части. ws:for вызовет рендер только первой колонки для заколспанненой записи. -->
    <ws:if data="{{itemData.columnScroll && colspan}}">
       <!-- Зафиксированная часть. -->
-      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-SwipeControl__actionsContainer {{ marker !== false ? currentColumn.classList.marked }}"
+      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
            style="{{currentColumn.gridCellStyles}} {{itemData.getCellStyle(itemData, currentColumn, false)}} {{itemData.getColspanForColumnScroll().fixedColumns}}">
          <ws:partial template="COLUMN_CONTENT"/>
       </div>
 
       <!-- Скроллируемая часть. -->
-      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}} {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-SwipeControl__actionsContainer {{ marker !== false ? currentColumn.classList.marked }}"
+      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}} {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
            style="{{currentColumn.gridCellStyles}} {{itemData.getCellStyle(itemData, currentColumn, false)}} {{itemData.getColspanForColumnScroll().scrollableColumns}}"></div>
    </ws:if>
    <ws:else>
-      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-SwipeControl__actionsContainer {{ marker !== false ? currentColumn.classList.marked }}"
+      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
            style="{{currentColumn.gridCellStyles + itemData.getCellStyle(itemData, currentColumn, colspan)}}">
          <ws:partial template="COLUMN_CONTENT"/>
       </div>
@@ -152,7 +152,7 @@
                                       {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}}
                                       {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}
                                       {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
-                                      js-controls-SwipeControl__actionsContainer {{ marker !== false ? currentColumn.classList.marked }}"
+                                      js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
                           attr:style="{{currentColumn.gridCellStyles + itemData.getCellStyle(itemData, currentColumn, colspan)}}">
       <ws:partial template="COLUMN_CONTENT"/>
    </Controls.scroll:StickyHeader>

--- a/Controls/_grid/layout/table/Item.wml
+++ b/Controls/_grid/layout/table/Item.wml
@@ -65,7 +65,7 @@
     <td colspan="{{ itemData.getColspanFor(colspanFor) }}"
         style="{{ currentColumn.tableCellStyles }}"
         attr:key="{{ itemData.getCurrentColumnKey() }}{{ keyPostfix ? ('_' + keyPostfix) : '' }}"
-        attr:class="js-controls-SwipeControl__actionsContainer
+        attr:class="js-controls-ItemActions__measurementContainer
                     {{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}}
                     {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}
                     {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}

--- a/Controls/_list/ItemTemplate.wml
+++ b/Controls/_list/ItemTemplate.wml
@@ -8,7 +8,7 @@
        {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-ListView__item_active_theme-' + itemData.theme}}
        {{!!itemData.isEditing() ? ' controls-ListView__item_editing_theme-' + itemData.theme}}
        {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
-       js-controls-SwipeControl__actionsContainer"
+       js-controls-ItemActions__measurementContainer"
        attr:key="{{itemData.item.getId()}}"
        template="{{content}}"
        theme="{{itemData.theme}}"/>

--- a/Controls/_listRender/Render.ts
+++ b/Controls/_listRender/Render.ts
@@ -111,9 +111,9 @@ export default class Render extends Control<IRenderOptions> {
             .closest('.controls-ListView__itemV');
 
         const swipeContainer =
-            itemContainer.classList.contains('js-controls-SwipeControl__actionsContainer')
+            itemContainer.classList.contains('js-controls-Swipe__measurementContainer')
             ? itemContainer
-            : itemContainer.querySelector('.js-controls-SwipeControl__actionsContainer');
+            : itemContainer.querySelector('.js-controls-Swipe__measurementContainer');
 
         this._notify('itemSwipe', [item, e, swipeContainer?.clientWidth, swipeContainer?.clientHeight]);
     }

--- a/Controls/_menu/Render/itemTemplate.wml
+++ b/Controls/_menu/Render/itemTemplate.wml
@@ -1,6 +1,6 @@
 <div attr:class="controls-Menu__row
                  controls-DropdownList__row
-                 controls-ListView__itemV js-controls-SwipeControl__actionsContainer
+                 controls-ListView__itemV js-controls-ItemActions__measurementContainer
                  {{itemData.itemClassList}} theme_{{_options.theme}}
                  {{marker !== false && treeItem.isSelected() &&
                   (!itemData.multiSelect || itemData.isEmptyItem || itemData.isFixedItem) ? 'controls-Menu__row_selected_theme-' + _options.theme}}

--- a/Controls/_tile/TileView/TileTpl.wml
+++ b/Controls/_tile/TileView/TileTpl.wml
@@ -10,7 +10,7 @@
                {{height === 'auto' ? 'controls-TileView__item_autoHeight'}}
                {{highlightOnHover === true ? ' controls-TileView__itemContent_highlightOnHover_theme-' + theme}}
                {{backgroundColorStyle ? ' controls-TileView__itemContent_background_' + backgroundColorStyle +'_theme-' + theme}}
-               js-controls-SwipeControl__actionsContainer
+               js-controls-ItemActions__measurementContainer
                {{!!itemData.isActive() ? ' controls-TileView__item_active_theme-' + theme}}
                {{!!itemData.isSwiped() ? ' controls-TileView__item_swiped_theme-' + theme}}
                {{itemData.isHovered ? ' controls-TileView__item_hovered'}}

--- a/Controls/_tile/TreeTileView/FolderTpl.wml
+++ b/Controls/_tile/TreeTileView/FolderTpl.wml
@@ -1,4 +1,4 @@
-<div attr:class="controls-TileView__item controls-TileView__item_theme-{{theme}}  js-controls-TileView__withoutZoom controls-ListView__itemV controls-ListView__itemV_cursor-{{cursor || 'pointer'}} controls-TreeTileView__item_theme-{{theme}} js-controls-SwipeControl__actionsContainer
+<div attr:class="controls-TileView__item controls-TileView__item_theme-{{theme}}  js-controls-TileView__withoutZoom controls-ListView__itemV controls-ListView__itemV_cursor-{{cursor || 'pointer'}} controls-TreeTileView__item_theme-{{theme}} js-controls-ItemActions__measurementContainer
          {{' controls-ListView__item_shadow_' + (shadowVisibility || itemData.defaultShadowVisibility) + '_theme-' + theme}}
          controls-ListView__item_showActions
          {{backgroundColorStyle ? ' controls-TileView__itemContent_background_' + backgroundColorStyle +'_theme-' + theme}}

--- a/Controls/_treeGrid/TreeGridView/layout/table/Item.wml
+++ b/Controls/_treeGrid/TreeGridView/layout/table/Item.wml
@@ -54,7 +54,7 @@
               {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
               {{!!itemData.dragTargetNode ? ' js-controls-TreeView__dragTargetNode'}}
               {{ marker !== false ? currentColumn.classList.marked }}
-              controls-TreeGrid__row js-controls-SwipeControl__actionsContainer"
+              controls-TreeGrid__row js-controls-ItemActions__measurementContainer"
             style="{{ currentColumn.tableCellStyles }}"
             colspan="{{(colspan === false && !!colspanLength) ? (currentColumn.columnIndex === (itemData.hasMultiSelect ? 1 : 0) ? colspanLength : 1) : itemData.getColspanFor((itemData.multiSelectVisibility !== 'hidden' && currentColumn.columnIndex == 0) ? 'multiSelectColumn' : (colspan || colspanCurrentNode ? 'node'))}}">
             <div class="controls-TreeGridView__row-cell_innerWrapper {{ currentColumn.classList.relativeCellWrapper }} {{itemData.columnIndex === 0 && !itemData.hasMultiSelect ? currentColumn.classList.padding.left }}">
@@ -143,7 +143,7 @@
               {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}
               {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
               {{!!itemData.dragTargetNode ? ' js-controls-TreeView__dragTargetNode'}}
-              controls-TreeGrid__row js-controls-SwipeControl__actionsContainer"
+              controls-TreeGrid__row js-controls-ItemActions__measurementContainer"
             colspan="1"
             style="width: 0; min-width: 0; max-width: 0; padding: 0px; overflow: visible; z-index: 3;">
             <div class="controls-TreeGridView__row-cell_innerWrapper {{ currentColumn.classList.relativeCellWrapper }}">

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4399,6 +4399,41 @@ define([
                spySetMarkedKey.restore();
             });
          });
+
+         // Должен правильно рассчитывать ширину для записей списка при отображении опций свайпа
+         // Предполагаем, что контейнер содержит класс js-controls-Swipe__measurementContainer
+         it('should correctly calculate row size for list', () => {
+            // fake HTMLElement
+            const fakeElement = {
+               classList: {
+                  contains: (selector) => true,
+               },
+               clientWidth: 500,
+               clientHeight: 31
+            };
+            const _result = lists.BaseControl._private.getSwipeContainerSize(fakeElement);
+            assert.equal(_result.width, 500);
+            assert.equal(_result.height, 31);
+         });
+
+         // Должен правильно рассчитывать ширину для записей таблицы при отображении опций свайпа
+         // Предполагаем, что сам контейнер не содержит класс js-controls-Swipe__measurementContainer,
+         // а его потомки содержат
+         it('should correctly calculate row size for grid', () => {
+            // fake HTMLElement
+            const fakeElement = {
+               classList: {
+                  contains: (selector) => false,
+               },
+               querySelectorAll: (selector) => (new Array(5)).map((el) => ({
+                  clientWidth: 50,
+                  clientHeight: 31
+               }))
+            };
+            const _result = lists.BaseControl._private.getSwipeContainerSize(fakeElement);
+            assert.equal(_result.width, 250);
+            assert.equal(_result.height, 31);
+         });
       });
 
       describe('ItemActions menu', () => {

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4425,10 +4425,10 @@ define([
                classList: {
                   contains: (selector) => false,
                },
-               querySelectorAll: (selector) => (new Array(5)).map((el) => ({
+               querySelectorAll: (selector) => (new Array(5)).fill({
                   clientWidth: 50,
                   clientHeight: 31
-               }))
+               })
             };
             const _result = lists.BaseControl._private.getSwipeContainerSize(fakeElement);
             assert.equal(_result.width, 250);

--- a/tests/ControlsUnit/display/CollectionItem.test.ts
+++ b/tests/ControlsUnit/display/CollectionItem.test.ts
@@ -469,7 +469,7 @@ describe('Controls/_display/CollectionItem', () => {
             'controls-ListView__item_highlightOnHover_default_theme_default',
             'controls-ListView__item_default',
             'controls-ListView__item_showActions',
-            'js-controls-SwipeControl__actionsContainer'
+            'js-controls-Swipe__measurementContainer'
         ];
         const editingClasses = [
             'controls-ListView__item_editing'

--- a/tests/ControlsUnit/display/TileCollectionItem.test.ts
+++ b/tests/ControlsUnit/display/TileCollectionItem.test.ts
@@ -287,7 +287,7 @@ describe('Controls/_display/TileCollectionItem', () => {
             const classes = item.getTileContentClasses();
 
             assert.include(classes, 'controls-TileView__itemContent');
-            assert.include(classes, 'js-controls-SwipeControl__actionsContainer');
+            assert.include(classes, 'js-controls-Swipe__measurementContainer');
             assert.include(classes, 'controls-ListView__item_shadow_#visibility#');
             assert.include(classes, 'controls-TileView__item_withoutMarker');
         });


### PR DESCRIPTION
https://online.sbis.ru/doc/711ef7d3-16b0-4676-9fb3-efe3f0aac983  iPad 13 / Свайп в двухколоночном реестре
Обрезается свайп по высоте в однострочных записях у первой записи в лесенке.
Шаги:
1. Задачи на мне (Демо_тензор/Демо123)
2. Свайпнуть запись, с фотографией и текстом в одну строку, после которой будет еще запись с этого же аккаунта (скрин)
ФР - открываются операции, обрезаются сверху и снизу
ОР - операции не обрезаются.