### PR TITLE
Документ №1179819976 от 2020-07-30 Чернобаев Д.В.

### DIFF
--- a/Controls-demo/Explorer/resources/CustomItemContent.wml
+++ b/Controls-demo/Explorer/resources/CustomItemContent.wml
@@ -1,4 +1,4 @@
-<div class="controls-TileView__imageWrapper js-controls-ItemActions__measurementContainer">
+<div class="controls-TileView__imageWrapper js-controls-ItemActions__swipeMeasurementContainer">
    <div class="{{hasTitle ? 'controls-TileView__resizer_theme-' + itemData.theme}}" style="{{'padding-top: ' + (itemData.itemsHeight / width) * 100 + '%;'}}"></div>
    <img class="controls-TileView__image demo-Explorer__image" src="{{itemData.item[itemData.imageProperty]}}"/>
    <ws:partial if="{{itemData.isSwiped && itemData.drawActions}}"

--- a/Controls/_display/CollectionItem.ts
+++ b/Controls/_display/CollectionItem.ts
@@ -417,7 +417,7 @@ export default class CollectionItem<T> extends mixin<
         return `controls-ListView__itemV
             controls-ListView__item_default
             controls-ListView__item_showActions
-            js-controls-Swipe__measurementContainer
+            js-controls-ItemActions__swipeMeasurementContainer
             ${templateHighlightOnHover ? 'controls-ListView__item_highlightOnHover_default_theme_default' : ''}
             ${this.isEditing() ? ` controls-ListView__item_editing_theme-${theme}` : ''}
             ${this.isDragged() ? ` controls-ListView__item_dragging_theme-${theme}` : ''}`;

--- a/Controls/_display/GridColumn.ts
+++ b/Controls/_display/GridColumn.ts
@@ -46,7 +46,7 @@ export default class GridColumn<T> extends mixin<
 
     getCellClasses(templateHighlightOnHover: boolean): string {
         // GridViewModel -> getItemColumnCellClasses
-        let classes = 'controls-Grid__row-cell controls-Grid__row-cell_theme-default js-controls-Swipe__measurementContainer';
+        let classes = 'controls-Grid__row-cell controls-Grid__row-cell_theme-default js-controls-ItemActions__swipeMeasurementContainer';
 
         // if !checkBoxCell
         classes += ' controls-Grid__cell_fit';

--- a/Controls/_display/TileCollectionItem.ts
+++ b/Controls/_display/TileCollectionItem.ts
@@ -122,7 +122,7 @@ export default class TileCollectionItem<T> extends CollectionItem<T> {
 
     getTileContentClasses(templateShadowVisibility?: string, templateMarker?: boolean, theme?:string): string {
         const theme = `_theme-${theme}`;
-        let classes = `controls-TileView__itemContent controls-TileView__itemContent${theme} js-controls-Swipe__measurementContainer`;
+        let classes = `controls-TileView__itemContent controls-TileView__itemContent${theme} js-controls-ItemActions__swipeMeasurementContainer`;
         classes += ` controls-ListView__item_shadow_${this.getShadowVisibility(templateShadowVisibility)}${theme}`;
         if (this.isActive()) {
             classes += ` controls-TileView__item_active${theme}`;

--- a/Controls/_grid/layout/grid/Item.wml
+++ b/Controls/_grid/layout/grid/Item.wml
@@ -57,7 +57,7 @@
                      attr:class="{{currentColumn.column.align ? ' controls-Grid__row-cell__content_halign_' + currentColumn.column.align : ''}}
                                  {{!isLadderHeader && currentColumn.hiddenForLadder && !colspan ? 'controls-Grid__row-cell__content_hiddenForLadder  controls-Grid__row-cell__content_hiddenForLadder_theme-' + itemData.theme}}
                                  {{!isLadderHeader && itemData.stickyLadder ? 'controls-Grid__row-cell__content_ladderHeader'}}
-                                 {{itemData.stickyLadder && itemData.stickyProperties[1] && !itemData.stickyLadder[itemData.stickyProperties[1]].ladderLength ? 'controls-Grid__row-cell__content_ladder-empty'}} 
+                                 {{itemData.stickyLadder && itemData.stickyProperties[1] && !itemData.stickyLadder[itemData.stickyProperties[1]].ladderLength ? 'controls-Grid__row-cell__content_ladder-empty'}}
                                  {{itemData.isRightSwiped() ? ' controls-ListView__item_rightSwipeAnimation'}}
                                  {{currentColumn.column.valign ?' controls-Grid__cell_valign_' + currentColumn.column.valign + ' controls-Grid__cell-content_full-height' : ''}}"
                      itemData="{{currentColumn}}"
@@ -80,7 +80,7 @@
 
 <ws:template name="STICKY_LADDER_HEADER">
    <ws:if data="{{itemData.stickyLadder[stickyProperty].headingStyle && currentColumn.hiddenForLadder}}">
-      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer"
+      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__swipeMeasurementContainer"
            attr:key="{{itemData.key + stickyProperty + '_sticky_ladder'}}"
            attr:style="{{itemData.stickyLadder[stickyProperty].headingStyle}}">
 
@@ -112,17 +112,17 @@
    <!-- Данный выводятся в зафиксированной части. ws:for вызовет рендер только первой колонки для заколспанненой записи. -->
    <ws:if data="{{itemData.columnScroll && colspan}}">
       <!-- Зафиксированная часть. -->
-      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
+      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__swipeMeasurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
            style="{{currentColumn.gridCellStyles}} {{itemData.getCellStyle(itemData, currentColumn, false)}} {{itemData.getColspanForColumnScroll().fixedColumns}}">
          <ws:partial template="COLUMN_CONTENT"/>
       </div>
 
       <!-- Скроллируемая часть. -->
-      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}} {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
+      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}} {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__swipeMeasurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
            style="{{currentColumn.gridCellStyles}} {{itemData.getCellStyle(itemData, currentColumn, false)}} {{itemData.getColspanForColumnScroll().scrollableColumns}}"></div>
    </ws:if>
    <ws:else>
-      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
+      <div class="{{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}} {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}} {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__swipeMeasurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
            style="{{currentColumn.gridCellStyles + itemData.getCellStyle(itemData, currentColumn, colspan)}}">
          <ws:partial template="COLUMN_CONTENT"/>
       </div>
@@ -153,7 +153,7 @@
                                       {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}}
                                       {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}
                                       {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
-                                      js-controls-ItemActions__measurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
+                                      js-controls-ItemActions__swipeMeasurementContainer {{ marker !== false ? currentColumn.classList.marked }}"
                           attr:style="{{currentColumn.gridCellStyles + itemData.getCellStyle(itemData, currentColumn, colspan)}}">
       <ws:partial template="COLUMN_CONTENT"/>
    </Controls.scroll:StickyHeader>

--- a/Controls/_grid/layout/table/Item.wml
+++ b/Controls/_grid/layout/table/Item.wml
@@ -65,7 +65,7 @@
     <td colspan="{{ itemData.getColspanFor(colspanFor) }}"
         style="{{ currentColumn.tableCellStyles }}"
         attr:key="{{ itemData.getCurrentColumnKey() }}{{ keyPostfix ? ('_' + keyPostfix) : '' }}"
-        attr:class="js-controls-ItemActions__measurementContainer
+        attr:class="js-controls-ItemActions__swipeMeasurementContainer
                     {{currentColumn.classList.base}} {{currentColumn.classList.columnScroll}}
                     {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}
                     {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}

--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -430,9 +430,10 @@ export class Controller {
     }
 
     /**
-     * Получает для указанного элемента коллекции набор опций записи для контекстного меню, отфильтрованный по parentAction
-     * Если parentAction - кнопка вызова дополнительного меню или parentAction не указан, то элементы фильтруются по showType.
+     * Получает для указанного элемента коллекции набор опций записи для меню, отфильтрованный по parentAction
+     * Если parentAction - кнопка вызова специального меню или parentAction не указан, то элементы фильтруются по showType.
      * Если parentAction содержит id, то элементы фильтруются по parent===id.
+     * Если был сделан свайп по элементу, то возвращаются все доступные опции записи.
      * @see http://axure.tensor.ru/standarts/v7/%D0%BA%D0%BE%D0%BD%D1%82%D0%B5%D0%BA%D1%81%D1%82%D0%BD%D0%BE%D0%B5_%D0%BC%D0%B5%D0%BD%D1%8E__%D0%B2%D0%B5%D1%80%D1%81%D0%B8%D1%8F_1_.html
      * @param item
      * @param parentAction
@@ -441,6 +442,9 @@ export class Controller {
     private _getMenuActions(item: IItemActionsItem, parentAction: IShownItemAction): IItemAction[] {
         const actions = item.getActions();
         const allActions = actions && actions.all;
+        if (item.isSwiped() && parentAction._isMenu) {
+            return allActions;
+        }
         if (allActions) {
             return allActions.filter((action) => (
                 ((!parentAction || parentAction._isMenu) && action.showType !== TItemActionShowType.TOOLBAR) ||

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -125,7 +125,7 @@ const DRAG_SHIFT_LIMIT = 4;
 const IE_MOUSEMOVE_FIX_DELAY = 50;
 const DRAGGING_OFFSET = 10;
 
-const SWIPE_MEASUREMENT_CONTAINER_SELECTOR = 'js-controls-Swipe__measurementContainer';
+const SWIPE_MEASUREMENT_CONTAINER_SELECTOR = 'js-controls-ItemActions__swipeMeasurementContainer';
 
 interface IAnimationEvent extends Event {
     animationName: string;

--- a/Controls/_list/ItemTemplate.wml
+++ b/Controls/_list/ItemTemplate.wml
@@ -8,7 +8,7 @@
        {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-ListView__item_active_theme-' + itemData.theme}}
        {{!!itemData.isEditing() ? ' controls-ListView__item_editing_theme-' + itemData.theme}}
        {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
-       js-controls-ItemActions__measurementContainer"
+       js-controls-ItemActions__swipeMeasurementContainer"
        attr:key="{{itemData.item.getId()}}"
        template="{{content}}"
        theme="{{itemData.theme}}"/>

--- a/Controls/_listRender/Render.ts
+++ b/Controls/_listRender/Render.ts
@@ -111,9 +111,9 @@ export default class Render extends Control<IRenderOptions> {
             .closest('.controls-ListView__itemV');
 
         const swipeContainer =
-            itemContainer.classList.contains('js-controls-Swipe__measurementContainer')
+            itemContainer.classList.contains('js-controls-ItemActions__swipeMeasurementContainer')
             ? itemContainer
-            : itemContainer.querySelector('.js-controls-Swipe__measurementContainer');
+            : itemContainer.querySelector('.js-controls-ItemActions__swipeMeasurementContainer');
 
         this._notify('itemSwipe', [item, e, swipeContainer?.clientWidth, swipeContainer?.clientHeight]);
     }

--- a/Controls/_menu/Render/itemTemplate.wml
+++ b/Controls/_menu/Render/itemTemplate.wml
@@ -1,6 +1,6 @@
 <div attr:class="controls-Menu__row
                  controls-DropdownList__row
-                 controls-ListView__itemV js-controls-ItemActions__measurementContainer
+                 controls-ListView__itemV js-controls-ItemActions__swipeMeasurementContainer
                  {{itemData.itemClassList}} theme_{{_options.theme}}
                  {{marker !== false && treeItem.isSelected() &&
                   (!itemData.multiSelect || itemData.isEmptyItem || itemData.isFixedItem) ? 'controls-Menu__row_selected_theme-' + _options.theme}}

--- a/Controls/_tile/TileView/TileTpl.wml
+++ b/Controls/_tile/TileView/TileTpl.wml
@@ -10,7 +10,7 @@
                {{height === 'auto' ? 'controls-TileView__item_autoHeight'}}
                {{highlightOnHover === true ? ' controls-TileView__itemContent_highlightOnHover_theme-' + theme}}
                {{backgroundColorStyle ? ' controls-TileView__itemContent_background_' + backgroundColorStyle +'_theme-' + theme}}
-               js-controls-ItemActions__measurementContainer
+               js-controls-ItemActions__swipeMeasurementContainer
                {{!!itemData.isActive() ? ' controls-TileView__item_active_theme-' + theme}}
                {{!!itemData.isSwiped() ? ' controls-TileView__item_swiped_theme-' + theme}}
                {{itemData.isHovered ? ' controls-TileView__item_hovered'}}

--- a/Controls/_tile/TreeTileView/FolderTpl.wml
+++ b/Controls/_tile/TreeTileView/FolderTpl.wml
@@ -1,4 +1,4 @@
-<div attr:class="controls-TileView__item controls-TileView__item_theme-{{theme}}  js-controls-TileView__withoutZoom controls-ListView__itemV controls-ListView__itemV_cursor-{{cursor || 'pointer'}} controls-TreeTileView__item_theme-{{theme}} js-controls-ItemActions__measurementContainer
+<div attr:class="controls-TileView__item controls-TileView__item_theme-{{theme}}  js-controls-TileView__withoutZoom controls-ListView__itemV controls-ListView__itemV_cursor-{{cursor || 'pointer'}} controls-TreeTileView__item_theme-{{theme}} js-controls-ItemActions__swipeMeasurementContainer
          {{' controls-ListView__item_shadow_' + (shadowVisibility || itemData.defaultShadowVisibility) + '_theme-' + theme}}
          controls-ListView__item_showActions
          {{backgroundColorStyle ? ' controls-TileView__itemContent_background_' + backgroundColorStyle +'_theme-' + theme}}

--- a/Controls/_treeGrid/TreeGridView/layout/grid/Item.wml
+++ b/Controls/_treeGrid/TreeGridView/layout/grid/Item.wml
@@ -134,7 +134,7 @@
 
 <ws:template name="STICKY_LADDER_HEADER">
    <ws:if data="{{itemData.stickyLadder[stickyProperty].headingStyle && currentColumn.hiddenForLadder}}">
-      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-SwipeControl__actionsContainer"
+      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__swipeMeasurementContainer"
            attr:key="{{itemData.key + stickyProperty + '_sticky_ladder'}}"
            attr:style="{{itemData.stickyLadder[stickyProperty].headingStyle}}">
 
@@ -174,7 +174,7 @@
                        {{ marker !== false ? currentColumn.classList.marked }}
                        {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
                        {{!!itemData.dragTargetNode ? ' js-controls-TreeView__dragTargetNode'}}
-                       controls-TreeGrid__row js-controls-SwipeControl__actionsContainer"
+                       controls-TreeGrid__row js-controls-ItemActions__swipeMeasurementContainer"
            style="{{currentColumn.gridCellStyles + itemData.getCellStyle(itemData, currentColumn, colspan || colspanCurrentNode) }}
                   {{ (colspan === false && !!colspanLength) && (currentColumn.columnIndex === (itemData.hasMultiSelect ? 1 : 0)) ? itemData.getPartialColspanStyles(itemData.hasMultiSelect ? 1 : 0, colspanLength) }}">
       <ws:partial template="COLUMN_CONTENT_WRAPPER"/>
@@ -214,7 +214,7 @@
                                    {{itemData.hasMultiSelect && currentColumn.columnIndex === 0 ? currentColumn.classList.padding.getAll()}}
                                    {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
                                    {{!!itemData.dragTargetNode ? ' js-controls-TreeView__dragTargetNode'}}
-                                   controls-TreeGrid__row js-controls-SwipeControl__actionsContainer"
+                                   controls-TreeGrid__row js-controls-ItemActions__swipeMeasurementContainer"
                                  attr:style="{{currentColumn.gridCellStyles + itemData.getCellStyle(itemData, currentColumn, colspan || colspanCurrentNode)}}">
       <ws:partial template="COLUMN_CONTENT_WRAPPER"/>
    </Controls.scroll:StickyHeader>

--- a/Controls/_treeGrid/TreeGridView/layout/table/Item.wml
+++ b/Controls/_treeGrid/TreeGridView/layout/table/Item.wml
@@ -55,7 +55,7 @@
               {{!!itemData.dragTargetNode ? ' js-controls-TreeView__dragTargetNode'}}
               {{ colspan ? 'controls-Grid__row-cell_colspaned'}}
               {{ marker !== false ? currentColumn.classList.marked }}
-              controls-TreeGrid__row js-controls-ItemActions__measurementContainer"
+              controls-TreeGrid__row js-controls-ItemActions__swipeMeasurementContainer"
             style="{{ currentColumn.tableCellStyles }}"
             colspan="{{(colspan === false && !!colspanLength) ? (currentColumn.columnIndex === (itemData.hasMultiSelect ? 1 : 0) ? colspanLength : 1) : itemData.getColspanFor((itemData.multiSelectVisibility !== 'hidden' && currentColumn.columnIndex == 0) ? 'multiSelectColumn' : (colspan || colspanCurrentNode ? 'node'))}}">
             <div class="controls-TreeGridView__row-cell_innerWrapper {{ currentColumn.classList.relativeCellWrapper }} {{itemData.columnIndex === 0 && !itemData.hasMultiSelect ? currentColumn.classList.padding.left }}">
@@ -144,7 +144,7 @@
               {{!!itemData.isActive() && highlightOnHover !== false ? ' controls-GridView__item_active_theme-' + itemData.theme}}
               {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
               {{!!itemData.dragTargetNode ? ' js-controls-TreeView__dragTargetNode'}}
-              controls-TreeGrid__row js-controls-ItemActions__measurementContainer"
+              controls-TreeGrid__row js-controls-ItemActions__swipeMeasurementContainer"
             colspan="1"
             style="width: 0; min-width: 0; max-width: 0; padding: 0px; overflow: visible; z-index: 3;">
             <div class="controls-TreeGridView__row-cell_innerWrapper {{ currentColumn.classList.relativeCellWrapper }}">

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4403,7 +4403,7 @@ define([
          });
 
          // Должен правильно рассчитывать ширину для записей списка при отображении опций свайпа
-         // Предполагаем, что контейнер содержит класс js-controls-Swipe__measurementContainer
+         // Предполагаем, что контейнер содержит класс js-controls-ItemActions__swipeMeasurementContainer
          it('should correctly calculate row size for list', () => {
             // fake HTMLElement
             const fakeElement = {
@@ -4419,7 +4419,7 @@ define([
          });
 
          // Должен правильно рассчитывать ширину для записей таблицы при отображении опций свайпа
-         // Предполагаем, что сам контейнер не содержит класс js-controls-Swipe__measurementContainer,
+         // Предполагаем, что сам контейнер не содержит класс js-controls-ItemActions__swipeMeasurementContainer,
          // а его потомки содержат
          it('should correctly calculate row size for grid', () => {
             // fake HTMLElement

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4534,7 +4534,8 @@ define([
                      id: 2,
                      showType: 0
                   }]
-               })
+               }),
+               isSwiped: () => false
             };
             instance.saveOptions(cfg);
             instance._scrollController = {
@@ -4739,6 +4740,7 @@ define([
                      showType: 0
                   }]
                }),
+               isSwiped: () => false,
                setMarked: () => null
             };
             instance._itemActionsController.setActiveItem(breadcrumbItem);

--- a/tests/ControlsUnit/display/CollectionItem.test.ts
+++ b/tests/ControlsUnit/display/CollectionItem.test.ts
@@ -469,7 +469,7 @@ describe('Controls/_display/CollectionItem', () => {
             'controls-ListView__item_highlightOnHover_default_theme_default',
             'controls-ListView__item_default',
             'controls-ListView__item_showActions',
-            'js-controls-Swipe__measurementContainer'
+            'js-controls-ItemActions__swipeMeasurementContainer'
         ];
         const editingClasses = [
             'controls-ListView__item_editing'

--- a/tests/ControlsUnit/display/TileCollectionItem.test.ts
+++ b/tests/ControlsUnit/display/TileCollectionItem.test.ts
@@ -287,7 +287,7 @@ describe('Controls/_display/TileCollectionItem', () => {
             const classes = item.getTileContentClasses();
 
             assert.include(classes, 'controls-TileView__itemContent');
-            assert.include(classes, 'js-controls-Swipe__measurementContainer');
+            assert.include(classes, 'js-controls-ItemActions__swipeMeasurementContainer');
             assert.include(classes, 'controls-ListView__item_shadow_#visibility#');
             assert.include(classes, 'controls-TileView__item_withoutMarker');
         });

--- a/tests/ControlsUnit/itemActions/Controller.test.ts
+++ b/tests/ControlsUnit/itemActions/Controller.test.ts
@@ -1212,7 +1212,7 @@ describe('Controls/_itemActions/Controller', () => {
 
             // T3.7.2.2. parentAction задан и его _isMenu===true
             // T3.7.2.1.3. Среди экшнов отстутсвуют любые айтемы, у которых showtype===TOOLBAR
-            it('should collect any non-toolbar options when parentAction._isMenu===true', () => {
+            it('should collect any non-toolbar item actions when parentAction._isMenu===true', () => {
                 const localItemActions: IItemAction[] = [
                     {
                         id: 1,
@@ -1260,7 +1260,7 @@ describe('Controls/_itemActions/Controller', () => {
             });
 
             // T3.7.2.1.2. Среди экшнов присутствуют айтемы, у которых showtype===TOOLBAR
-            it('should collect only non-toolbar options when parentAction._isMenu===true', () => {
+            it('should collect only non-toolbar item actions when parentAction._isMenu===true', () => {
                 const localItemActions: IItemAction[] = [
                     {
                         id: 1,
@@ -1296,10 +1296,10 @@ describe('Controls/_itemActions/Controller', () => {
                     actionAlignment: 'vertical'
                 }));
                 const item3 = collection.getItemBySourceKey(3);
-                // @ts-ignore
                 const config = itemActionsController.prepareActionsMenuConfig(
                     item3,
                     clickEvent,
+                    // @ts-ignore
                     parentAction,
                     null,
                     false
@@ -1315,6 +1315,59 @@ describe('Controls/_itemActions/Controller', () => {
                 const unexpectedActions = config.templateOptions.source.data
                     .filter((action) => action.showType === TItemActionShowType.TOOLBAR);
                 assert.isEmpty(unexpectedActions);
+            });
+
+            it('should collect all item actions when item is swiped', () => {
+                const localItemActions: IItemAction[] = [
+                    {
+                        id: 1,
+                        icon: 'icon-PhoneNull',
+                        title: 'phone',
+                        showType: TItemActionShowType.MENU
+                    },
+                    {
+                        id: 5,
+                        title: 'Documentation',
+                        showType: TItemActionShowType.TOOLBAR,
+                        parent: 4
+                    },
+                    {
+                        id: 6,
+                        title: 'Development',
+                        showType: TItemActionShowType.MENU_TOOLBAR,
+                        parent: 4
+                    }
+                ];
+                const parentAction = {
+                    id: null,
+                    icon: 'icon-ExpandDown',
+                    style: 'secondary',
+                    iconStyle: 'secondary',
+                    _isMenu: true
+                };
+                // @ts-ignore
+                itemActionsController.update(initializeControllerOptions({
+                    collection,
+                    itemActions: localItemActions,
+                    theme: 'default',
+                    actionAlignment: 'vertical'
+                }));
+                const item3 = collection.getItemBySourceKey(3);
+
+                item3.setSwiped(true, true);
+                const config = itemActionsController.prepareActionsMenuConfig(
+                    item3,
+                    clickEvent,
+                    // @ts-ignore
+                    parentAction,
+                    null,
+                    false
+                );
+                assert.exists(config.templateOptions, 'Template options were not set');
+                // @ts-ignore
+                assert.exists(config.templateOptions.source, 'Menu actions source hasn\'t set in template options');
+                // @ts-ignore
+                assert.deepEqual(config.templateOptions.source.data, localItemActions);
             });
         });
 

--- a/tests/ControlsUnit/listRender/View.test.ts
+++ b/tests/ControlsUnit/listRender/View.test.ts
@@ -151,7 +151,8 @@ describe('Controls/_listRender/View', () => {
                         id: 2,
                         showType: 0
                     }]
-                })
+                }),
+                isSwiped: () => false
             };
             view._collection = {
                 _$activeItem: null,


### PR DESCRIPTION
https://online.sbis.ru/doc/f43a6f8e-84a5-4f22-b67f-4545bf586adc  IPAD.  Не кликабельна кнопка троеточия "..." при свайпе справа налево у папки и клиента, если вызвать ПМО в реестре Клиенты 
Как повторить:  
1. Салон -> Клиенты
2. Свайпнуть справа налево у папки или клиента при вызванной ПМО
ФР:  
Не кликабельна кнопка троеточия "..."
ОР:  
Кнопка троеточия "..." кликабельна
Страница: Салон красоты/СБИС
Логин: Пароль:   
UserAgent: Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1
Версия:
online-inside_20.5100 (ver 20.5100) - 769 (30.07.2020 - 12:00:01)
Platforma 20.5100 - 18 (30.07.2020 - 07:41:28)
WS 20.5100 - 22 (30.07.2020 - 09:27:11)
Types 20.5100 - 15 (30.07.2020 - 07:26:00)
CONTROLS 20.5100 - 26 (30.07.2020 - 08:48:14)
SDK 20.5100 - 93 (30.07.2020 - 11:17:57)
DISTRIBUTION: inside
GenerateDate: 30.07.2020 - 12:00:01
autoerror_sbislogs 30.07.2020