### PR TITLE
Документ №1179802249 от 2020-07-28 Вялов М.С.

### DIFF
--- a/Controls/_grid/layout/grid/Item.wml
+++ b/Controls/_grid/layout/grid/Item.wml
@@ -80,19 +80,19 @@
 
 <ws:template name="STICKY_LADDER_HEADER">
    <ws:if data="{{itemData.stickyLadder[stickyProperty].headingStyle && currentColumn.hiddenForLadder}}">
-      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__swipeMeasurementContainer"
+      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}"
            attr:key="{{itemData.key + stickyProperty + '_sticky_ladder'}}"
            attr:style="{{itemData.stickyLadder[stickyProperty].headingStyle}}">
 
          <ws:if data="{{itemData.stickyProperties[index]}}">
             <ws:if data="{{index === 1}}">
-               <div class="controls-Grid__row-additional_ladderWrapper" 
+               <div class="controls-Grid__row-additional_ladderWrapper"
                   style="{{ 'right: 0; left: -' + currentColumn.column.width }};">
                   <ws:partial template="STICKY_LADDER_HEADER_CONTENT" attr:class="{{itemData.getAdditionalLadderClasses()}}" attr:style="z-index: 1" currentColumn="{{currentColumn}}" stickyProperty="{{stickyProperty}}"/>
                </div>
             </ws:if>
             <ws:else>
-               <div class="controls-Grid__row-main_ladderWrapper" 
+               <div class="controls-Grid__row-main_ladderWrapper"
                   style="{{ 'left: 0; right: -'+ currentColumn.column.width }};">
                   <ws:partial template="STICKY_LADDER_HEADER_CONTENT"  attr:style="z-index: 2" currentColumn="{{currentColumn}}" stickyProperty="{{stickyProperty}}"/>
                </div>

--- a/Controls/_treeGrid/TreeGridView/layout/grid/Item.wml
+++ b/Controls/_treeGrid/TreeGridView/layout/grid/Item.wml
@@ -134,19 +134,19 @@
 
 <ws:template name="STICKY_LADDER_HEADER">
    <ws:if data="{{itemData.stickyLadder[stickyProperty].headingStyle && currentColumn.hiddenForLadder}}">
-      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}} js-controls-ItemActions__swipeMeasurementContainer"
+      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}"
            attr:key="{{itemData.key + stickyProperty + '_sticky_ladder'}}"
            attr:style="{{itemData.stickyLadder[stickyProperty].headingStyle}}">
 
          <ws:if data="{{itemData.stickyProperties[index]}}">
             <ws:if data="{{index === 1}}">
-               <div class="controls-Grid__row-additional_ladderWrapper" 
+               <div class="controls-Grid__row-additional_ladderWrapper"
                   style="{{ 'right: 0; left: -' + currentColumn.column.width }};">
                   <ws:partial template="STICKY_LADDER_HEADER_CONTENT" attr:class="{{itemData.getAdditionalLadderClasses()}}" attr:style="z-index: 1" currentColumn="{{currentColumn}}" stickyProperty="{{stickyProperty}}"/>
                </div>
             </ws:if>
             <ws:else>
-               <div class="controls-Grid__row-main_ladderWrapper" 
+               <div class="controls-Grid__row-main_ladderWrapper"
                   style="{{ 'left: 0; right: -' + currentColumn.column.width }};">
                   <ws:partial template="STICKY_LADDER_HEADER_CONTENT"  attr:style="z-index: 2" currentColumn="{{currentColumn}}" stickyProperty="{{stickyProperty}}"/>
                </div>


### PR DESCRIPTION
https://online.sbis.ru/doc/711ef7d3-16b0-4676-9fb3-efe3f0aac983  iPad 13 / Свайп в двухколоночном реестре
Обрезается свайп по высоте в однострочных записях у первой записи в лесенке.
Шаги:
1. Задачи на мне (Демо_тензор/Демо123)
2. Свайпнуть запись, с фотографией и текстом в одну строку, после которой будет еще запись с этого же аккаунта (скрин)
ФР - открываются операции, обрезаются сверху и снизу
ОР - операции не обрезаются.