### PR TITLE
Документ №1179884056 от 2020-08-10 Туренков Е.В.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -36,6 +36,13 @@ import {IHeaderCell} from './interface/IHeaderCell';
 import { ItemsEntity } from 'Controls/dragnDrop';
 import { IDragPosition, IFlatItemData } from 'Controls/listDragNDrop';
 
+/**
+ * При установке этих значений следует учитывать, что z-index:
+ * .controls-Grid__cell_fixed_theme-@{themeName} = 3
+ * .controls-TreeGrid__row__searchBreadCrumbs .controls-itemActionsV__container = 4
+ * .controls-itemActionsV__container = 4
+ * .controls-Grid_columnScroll_wrapper = 5
+ */
 const FIXED_HEADER_ZINDEX = 6;
 const STICKY_HEADER_ZINDEX = 5;
 
@@ -277,14 +284,13 @@ var
             return isCellIndexLessTheFixedIndex;
         },
 
-
-        getHeaderZIndex: function(params) {
-            if (params.isColumnScrollVisible) {
-                return _private.isFixedCell(params) ? FIXED_HEADER_ZINDEX : STICKY_HEADER_ZINDEX;
-            } else {
-                // Пока в таблице нет горизонтального скролла, шапка ен может быть проскролена по горизонтали.
-                return FIXED_HEADER_ZINDEX;
-            }
+        // Раньше по https://online.sbis.ru/doc/a4b0487a-4bc4-47e4-afce-3340833b1232 тут ещё была проверка на
+        // isColumnScrollVisible, но это приводило к тому, что в некоторых реестрах
+        // z-index всех столбцов формировались до установки isColumnScrollVisible=true как FIXED_HEADER_ZINDEX
+        // и т.к. они были на одном уровне, то возникал кейс по ошибке
+        // https://online.sbis.ru/opendoc.html?guid=42614e54-3ed7-41f4-9d57-a6971df66f9c
+        getHeaderZIndex(params): number {
+            return _private.isFixedCell(params) ? FIXED_HEADER_ZINDEX : STICKY_HEADER_ZINDEX;
         },
 
         getColumnScrollCellClasses(params, theme): string {

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -2786,7 +2786,7 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             // fixed coll withoutColumnScroll
             assert.equal(6, gridMod.GridViewModel._private.getHeaderZIndex({...params, isColumnScrollVisible: false}));
             // sticky fit coll withoutColumnScroll
-            assert.equal(6, gridMod.GridViewModel._private.getHeaderZIndex({...params, isColumnScrollVisible: false, columnIndex: 1}));
+            assert.equal(5, gridMod.GridViewModel._private.getHeaderZIndex({...params, isColumnScrollVisible: false, columnIndex: 1}));
          })
 
          it('updates prefix version with ladder only on add and remove', () => {


### PR DESCRIPTION
https://online.sbis.ru/doc/42614e54-3ed7-41f4-9d57-a6971df66f9c  Документы. Горизонтальный скролл приводит к тому что заголовки столбцов наползают на 1 столбец.
Как повторить:  
1. Перейти в Сотрудники - Мотивация - Показатели KPI - Документ
2. Выбрать схему с большим количеством показателей
3. + документ
4. проскролировать список столбцов вправо
ФР:  заголовки столбцов наползают на 1 столбец.
ОР:  заглловки не накладываются на столбец
Страница: Показатели KPI/СБИС
Логин: slyfox2 Пароль: SlyFox2019  
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36
Версия:
online-inside_20.5100 (ver 20.5100) - 928 (10.08.2020 - 09:19:12)
Platforma 20.5100 - 91 (10.08.2020 - 06:41:00)
WS 20.5100 - 63 (10.08.2020 - 07:27:00)
Types 20.5100 - 54 (10.08.2020 - 07:26:00)
CONTROLS 20.5100 - 81 (10.08.2020 - 06:48:00)
SDK 20.5100 - 321 (10.08.2020 - 08:51:33)
DISTRIBUTION: ext
GenerateDate: 10.08.2020 - 09:19:12
autoerror_sbislogs 10.08.2020