### PR TITLE
Документ №1179889442 от 2020-08-10 Туренков Е.В.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1768,7 +1768,7 @@ var
         },
 
         setColumnScrollVisibility(columnScrollVisibility: boolean) {
-            if (!!this._options.columnScrollVisibility !== columnScrollVisibility) {
+            if (this._options && !!this._options.columnScrollVisibility !== columnScrollVisibility) {
                 this._options.columnScrollVisibility = columnScrollVisibility;
 
                 // Нужно обновить классы с z-index на всех ячейках

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -2240,6 +2240,25 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             assert.equal(newVersion - oldVersion, 1);
             oldVersion = newVersion;
          });
+
+         it('should not throw an error if column scroll visibility has been changed before unmount', function () {
+            const testModel = new gridMod.GridViewModel({
+               ...cfg,
+               items: new collection.RecordSet({
+                  rawData: [ { id: 1, group: 'once'} ],
+                  keyProperty: 'id'
+               })
+            });
+            const spySetColumnScrollVisibility = sinon.spy(testModel, 'setColumnScrollVisibility');
+            testModel.destroy();
+            try {
+               testModel.setColumnScrollVisibility(false);
+            } catch (e) {
+               // pass
+            }
+            assert.isFalse(spySetColumnScrollVisibility.threw());
+         });
+
          it('getColumnScrollCellClasses', function() {
             const backgroundStyle = 'controls-background-default_theme-default';
             const fixedCell = ` controls-Grid_columnScroll__fixed controls-Grid__cell_fixed controls-Grid__cell_fixed_theme-${theme}`;


### PR DESCRIPTION
https://online.sbis.ru/doc/9b91859e-4115-4cce-a510-37b8bea59ae7  Статистика 1 режим. Ошибка в консоль при поиске. 
LIFECYCLE ERROR:  IN "Controls/treeGrid:TreeGridView". HOOK NAME: "_beforeUnmount"
 ↱ Controls/treeGrid:TreeGridView
  ↱ Controls/dataSource:error.Container
   ↱ Controls/list:BaseControl
    ↱ Controls/dataSource:error.Container
     ↱ Controls/tree:TreeControl
      ↱ Core/Control
       ↱ Controls/dragnDrop:Container
        ↱ Controls/explorer:View
         ↱ Controls/operations:Container
          ↱ Controls/scroll:Watcher
           ↱ Controls/scroll:Container
            ↱ Controls/list:Container
             ↱ Controls/search:MisspellContainer
              ↱ Controls/browser:Browser
               ↱ Controls/filter:Controller
                ↱ Controls/operations:FilterController
                 ↱ Controls/search:FilterController
                  ↱ Layout/Browser
                   ↱ KPI2/Indicator/facesKPIsByMonth:List
                    ↱ Controls/Container/Async:template - "true" → Controls/switchableArea:itemTemplate → Controls/switchableArea:View → KPI2/Indicator/common:KPILoadController → KPI2/Indicator/statistic:Tab → Controls/Container/Async:template - "true" → Controls/switchableArea:itemTemplate → Controls/switchableArea:View → Layout/Browser/Tabs → KPI2/Indicator/main:Area → Controls/Container/Async:template - "true" → KPI2/IndexSPA → Controls/dataSource:error.Container → OnlinePage/Controller:Workspace → UI/Base:Control → OnlinePage/Controller:Informers → NoticeCenter/common:DisplayController → ParametersWebAPI/Scope:Controller → UI/Base:Control → UI/HotKeys:Dispatcher → Controls/dragnDrop:Controller → Controls/popup:Manager → Controls/Application/TouchDetector → Controls/popup:Global → UI/Base:HTML → Controls/Application → Page/Template:Entity → Notes/VDOM/Controller → OnlineSidebar/SidebarController → Hint/Popup:PopupManagerWrapper → ViewSettings/controller:Container → OnlinePage/Controller:Data → OnlinePage/Controller:SingletonDataLoader → OnlinePage/Base:View → UserActivity/Common:ActivityContextProvider → OnlineSbisRu/Controller:Informers → Permission/access:Controller → OnlineSbisRu/Base:View → OnlineSbisRu/Router:Router → OnlineSidebar/NavigationController → OnlineSbisRu/Index → UI/Base:Document
Stack: TypeError: Cannot read property 'columnScrollVisibility' of null
Как повторить:  
1. Перейти в Сотрудники - Мотивация - Показатели KPI
2. Выбрать режим "По списку за период" 
3. Ввести в поиск "Альфа"
ФР:  ошибка в консоль
ОР:  нет ошибки в консоль
Страница: Показатели KPI/СБИС
Логин: Пароль:   
UserAgent: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36
Версия:
online-inside_20.5100 (ver 20.5100) - 940 (10.08.2020 - 18:01:14)
Platforma 20.5100 - 94 (10.08.2020 - 16:41:28)
WS 20.5100 - 65 (10.08.2020 - 15:27:15)
Types 20.5100 - 55 (10.08.2020 - 14:26:09)
CONTROLS 20.5100 - 85 (10.08.2020 - 15:04:24)
SDK 20.5100 - 331 (10.08.2020 - 17:34:47)
DISTRIBUTION: ext
GenerateDate: 10.08.2020 - 18:01:14
autoerror_sbislogs 10.08.2020