### PR TITLE
Документ №1179836792 от 2020-08-03 Тихомиров А.А.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1041,6 +1041,7 @@ var
                 if (this._options.columnScrollVisibility) {
                     cellClasses += _private.getColumnScrollCellClasses(params, this._options.theme);
                 }
+                // Этот костыль выпилен в 6000 по https://online.sbis.ru/opendoc.html?guid=f5e830c3-7be2-4272-9c38-594c241401cc
                 if (this._options.columnScrollVisibility && this.isStickyHeader()) {
                     cellClasses += ' controls-Grid__columnScroll_will-transform';
                 }
@@ -1300,6 +1301,7 @@ var
                 if (this._options.columnScrollVisibility) {
                     cellClasses += _private.getColumnScrollCellClasses(params, this._options.theme);
                 }
+                // Этот костыль выпилен в 6000 по https://online.sbis.ru/opendoc.html?guid=f5e830c3-7be2-4272-9c38-594c241401cc
                 if (this._options.columnScrollVisibility && this.isStickyHeader()) {
                     cellClasses += ' controls-Grid__columnScroll_will-transform';
                 }

--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1041,6 +1041,9 @@ var
                 if (this._options.columnScrollVisibility) {
                     cellClasses += _private.getColumnScrollCellClasses(params, this._options.theme);
                 }
+                if (this._options.columnScrollVisibility && this.isStickyHeader()) {
+                    cellClasses += ' controls-Grid__columnScroll_will-transform';
+                }
             }
 
             // Если включен множественный выбор и рендерится первая колонка с чекбоксом
@@ -1296,6 +1299,9 @@ var
                 cellClasses += _private.getColumnScrollCalculationCellClasses(params, this._options.theme);
                 if (this._options.columnScrollVisibility) {
                     cellClasses += _private.getColumnScrollCellClasses(params, this._options.theme);
+                }
+                if (this._options.columnScrollVisibility && this.isStickyHeader()) {
+                    cellClasses += ' controls-Grid__columnScroll_will-transform';
                 }
 
                 if (!GridLayoutUtil.isFullGridSupport()) {

--- a/Controls/_grid/layout/grid/_Grid.less
+++ b/Controls/_grid/layout/grid/_Grid.less
@@ -68,6 +68,12 @@
    position: sticky;
 }
 
+/* Этот костыль выпилен в 6000 по https://online.sbis.ru/opendoc.html?guid=f5e830c3-7be2-4272-9c38-594c241401cc */
+.ws-is-desktop-safari .controls-Grid__columnScroll_will-transform,
+.ws-is-mobile-safari .controls-Grid__columnScroll_will-transform {
+   will-change: transform;
+}
+
 .controls-Grid__cell_spacing_money:after,
 /* deprecated, remove by https://online.sbis.ru/opendoc.html?guid=eff529b3-eb2a-4171-882d-4ff8e1e7e421 */
 .controls-Grid__header-cell_spacing_money:after {


### PR DESCRIPTION
https://online.sbis.ru/doc/f5e830c3-7be2-4272-9c38-594c241401cc  Mac os+safari. Едет верстка складских отчетов при скролле
1. https://pre-test-online.sbis.ru/business/ демо_тензор
2. создать продажи за период
3. скроллить вверх и вниз
ФР: в какой то момент заголовки таблицы и ползунок начинают скроллится вместе с реестром, потом сами встают на место, не смог повторить в др подобных реестрах
ОР: верстка не едет
подключение к MacOS возможно через программу TightVNC: хост usd-macprog8, пароль 1234, пользователь prog/prog, по окончанию работ выходите из под пользователя!