### PR TITLE
Документ №1179983635 от 2020-08-25 Розов Е.В.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1706,9 +1706,10 @@ var
             current.shouldAddActionsCell = self._shouldAddActionsCell();
             current.getCellStyle = (itemData, currentColumn, colspan) => _private.getCellStyle(self, itemData, currentColumn, colspan);
 
-            if (!GridLayoutUtil.isFullGridSupport()) {
-                current.getRelativeCellWrapperClasses = _private.getRelativeCellWrapperClasses.bind(null, current);
-            }
+            // Удалено в версии 7000
+            current.getRelativeCellWrapperClasses = !GridLayoutUtil.isFullGridSupport() ?
+                _private.getRelativeCellWrapperClasses.bind(null, current) :
+                () => '';
 
             current.getCurrentColumnKey = function() {
                 return self._columnsVersion + '_' +

--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1709,7 +1709,7 @@ var
             current.getRelativeCellWrapperClasses = !GridLayoutUtil.isFullGridSupport() ?
                 _private.getRelativeCellWrapperClasses.bind(null, current) :
                 () => {
-                    Logger.warn('Used table markup when full grid support. View may be displayed incorrectly!');
+                    Logger.warn('Used table markup when full grid support. View may be displayed incorrectly!', this);
                     return '';
                 };
 

--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1706,10 +1706,12 @@ var
             current.shouldAddActionsCell = self._shouldAddActionsCell();
             current.getCellStyle = (itemData, currentColumn, colspan) => _private.getCellStyle(self, itemData, currentColumn, colspan);
 
-            // Удалено в версии 7000
             current.getRelativeCellWrapperClasses = !GridLayoutUtil.isFullGridSupport() ?
                 _private.getRelativeCellWrapperClasses.bind(null, current) :
-                () => '';
+                () => {
+                    Logger.warn('Used table markup when full grid support. View may be displayed incorrectly!');
+                    return '';
+                };
 
             current.getCurrentColumnKey = function() {
                 return self._columnsVersion + '_' +


### PR DESCRIPTION
Ошибки в логах fix-cloud.sbis.ru. Метод: PSWaSabyRouting.NomenclatureRegistry. За период с 25.08.20 09:16:44 по 25.08.20 09:56:44 число повторений в логах (раз): 450.

Фильтр логов: От: 25.08.20 09:16:44.000+0300, До: 25.08.20 09:56:44.000+0300, Группа: ext-ps, Метод: PSWaSabyRouting.NomenclatureRegistry, Отобразить: ошибки

Перейти в логи

Server Javascript error: TEMPLATE ERROR - Failed to generate html IN "Controls/_treeGrid/TreeGridView/layout/table/Item"

Error: Field itemData.getRelativeCellWrapperClasses is not a function!
at Object.error [as templateError] (/opt/sbis/ext1/online-ps/ui/resources/View/Executor/TClosure.js:187:17)
at Object.u (eval at req.exec (/opt/sbis/ext1/online-ps/modules/Js ws adaptor/requirejs/require.js:2184:16), :1:18611)
at Object.e (eval at req.exec (/opt/sbis/ext1/online-ps/modules/Js ws adaptor/requirejs/require.js:2184:16), :1:21018)
at e (eval at req.exec (/opt/sbis/ext1/online-ps/modules/Js ws adaptor/requirejs/require.js:2184:16), :1:21429)
at BaseRegistry.e (eval at req.exec (/opt/sbis/ext1/online-ps/modules/Js ws adaptor/requirejs/require.js:2184:16), :1:21439)
at GeneratorText.resolver (/opt/sbis/ext1/online-ps/ui/resources/View/Executor/_Markup/Text/Generator.js:143:59)
at GeneratorText.Generator.createControl (/opt/sbis/ext1/online-ps/ui/resources/View/Executor/_Markup/Generator.js:94:36)
at GeneratorText.createControl (/opt/sbis/ext1/online-ps/ui/resources/View/Executor/_Markup/Text/Generator.js:20:53)
at Object.oe (eval at req.exec (/opt/sbis/ext1/online-ps/modules/Js ws adaptor/requirejs/require.js:2184:16), :1:14537)
at /opt/sbis/ext1/online-ps/ui/resources/View/Executor/_Markup/Text/Generator.js:157:54