### PR TITLE
Документ №1179899162 от 2020-08-12 Арсланова А.А.

### DIFF
--- a/Controls/_listRender/View.ts
+++ b/Controls/_listRender/View.ts
@@ -489,6 +489,13 @@ export default class View extends Control<IViewOptions> {
         });
     }
 
+    destroy(): void {
+        if (this._itemActionsMenuId) {
+            this._closePopup();
+        }
+        super.destroy();
+    }
+
     /**
      * Возвращает contents записи.
      * Если запись - breadcrumbs, то берётся последняя Model из списка contents

--- a/tests/ControlsUnit/listRender/View.test.ts
+++ b/tests/ControlsUnit/listRender/View.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import View, {IViewOptions} from 'Controls/_listRender/View';
 import { RecordSet } from 'Types/collection';
 
-import { stub } from 'sinon';
+import { stub, assert as sinonAssert } from 'sinon';
 import {IItemActionsItem} from 'Controls/itemActions';
 
 import 'Controls/display';
@@ -208,16 +208,19 @@ describe('Controls/_listRender/View', () => {
 
         // Не показываем контекстное меню браузера, если мы должны показать кастомное меню
         it('should prevent default context menu', () => {
+            let stubOpenPopup = stub(Sticky, 'openPopup').callsFake((config: IStickyPopupOptions) => (
+                Promise.resolve('fake')
+            ));
             view._onItemContextMenu(null, item, fakeEvent);
             assert.isTrue(fakeEvent.nativeEvent.prevented);
             assert.isFalse(fakeEvent.propagating);
+            stubOpenPopup.restore();
         });
 
         // Должен устанавливать contextMenuConfig при инициализации itemActionsController
         it('should set contextMenuConfig to itemActionsController', async () => {
             let popupConfig;
-            let stubOpenPopup = stub(Sticky, 'openPopup');
-            stubOpenPopup.callsFake((config: IStickyPopupOptions) => {
+            let stubOpenPopup = stub(Sticky, 'openPopup').callsFake((config: IStickyPopupOptions) => {
                 popupConfig = config;
                 return Promise.resolve(config);
             });
@@ -230,6 +233,14 @@ describe('Controls/_listRender/View', () => {
             assert.strictEqual(view._itemActionsController.getActiveItem(), null);
             assert.strictEqual(view._itemActionsController.getSwipeItem(), null);
             stubOpenPopup.restore();
+        });
+
+        it ('should close menu on destroy', () => {
+            view._itemActionsMenuId = 'fake';
+            const stubClosePopup = stub(Sticky, 'closePopup');
+            view.destroy();
+            sinonAssert.called(stubClosePopup);
+            stubClosePopup.restore();
         });
     });
 


### PR DESCRIPTION
https://online.sbis.ru/doc/84daceb3-c9a4-47d5-8ae4-57b27f53d15f  Остается висеть контекстное меню файла при исчезновении самого файла в реестре диалоговъ
Как повторить:  
1. (m-yoongi/m-yoongi123), вкадка Диалоги
2. отправить файл, открыть опции файла в реестре диалогов
3. получить сообщение в диалог с файлом
ФР:  файл исчезает, опции продолжают висеть
ОР:  при исчезновении файла контекстное меню диалога также исчезает
Страница: Контакты/СБИС
Логин: Пароль:   
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36
Версия:
online-inside_20.5100 (ver 20.5100) - 965 (12.08.2020 - 05:00:01)
Platforma 20.5100 - 99 (11.08.2020 - 13:41:36)
WS 20.5100 - 70 (11.08.2020 - 18:27:11)
Types 20.5100 - 60 (11.08.2020 - 17:26:12)
CONTROLS 20.5100 - 98 (11.08.2020 - 22:16:51)
SDK 20.5100 - 360 (11.08.2020 - 22:45:32)
DISTRIBUTION: ext
GenerateDate: 12.08.2020 - 05:00:01
autoerror_sbislogs 12.08.2020