### PR TITLE
Документ №1179965233 от 2020-08-21 Тихомиров А.А.

### DIFF
--- a/Controls/_itemActions/resources/templates/SwipeTwoColumns.wml
+++ b/Controls/_itemActions/resources/templates/SwipeTwoColumns.wml
@@ -17,5 +17,5 @@
         </ws:for>
     </div>
     <div if="{{columnIndex === 0}}" class="controls-Swipe__separator_theme-{{ theme }}
-        controls-Swipe__separator_horizontal"></div>
+        controls-Swipe__separator_horizontal_theme-{{ theme }}"></div>
 </ws:for>


### PR DESCRIPTION
https://online.sbis.ru/doc/0726a938-d232-4d78-93e6-e32cd330230d  iPad+safari, андроид планшет. В меню по свайпу не хватает вертикального разделителя при компоновке 4 команды в 2 этажа
1. https://fix-online.sbis.ru/contacts/
2. свайп влево по сообщению в 4 строки (скрин)
ФР: нет вертикального разделителя
ОР: есть