### PR TITLE
Документ №1179865040 от 2020-08-06 Елифантьев О.Н.

### DIFF
--- a/Controls-demo/list_new/ItemActions/ItemActionsBackground/Index.ts
+++ b/Controls-demo/list_new/ItemActions/ItemActionsBackground/Index.ts
@@ -1,0 +1,23 @@
+import {Control, IControlOptions, TemplateFunction} from 'UI/Base';
+import {IItemAction} from 'Controls/itemActions';
+import {Memory} from 'Types/source';
+
+import * as template from 'wml!Controls-demo/list_new/ItemActions/ItemActionsBackground/ItemActions';
+
+import {getContactsCatalog as getData} from '../../DemoHelpers/DataCatalog';
+import {getActionsForContacts as getItemActions} from '../../DemoHelpers/ItemActionsCatalog';
+
+export default class ListDelayedItemActions extends Control<IControlOptions> {
+   protected _itemActions: IItemAction[] = getItemActions();
+   protected _template: TemplateFunction = template;
+   protected _viewSource: Memory;
+
+   protected _beforeMount(options?: IControlOptions, contexts?: object, receivedState?: void): Promise<void> | void {
+      this._viewSource = new Memory({
+         keyProperty: 'id',
+         data: [getData().pop()]
+      });
+   }
+
+   static _styles: string[] = ['Controls-demo/Controls-demo', 'Controls-demo/list_new/ItemActions/ItemActionsBackground/ItemActionsBackground'];
+}

--- a/Controls-demo/list_new/ItemActions/ItemActionsBackground/ItemActions.wml
+++ b/Controls-demo/list_new/ItemActions/ItemActionsBackground/ItemActions.wml
@@ -1,0 +1,42 @@
+<div class="controlsDemo__wrapper controlsDemo_fixedWidth500">
+    <div class="Controls-ItemActionsBackground__transparent-area">
+        <div>Transparent</div>
+        <Controls.list:View
+                name="transparentOptions"
+                itemActionsBackgroundStyle="transparent"
+                keyProperty="id"
+                source="{{_viewSource}}"
+                itemActions="{{_itemActions}}">
+            <ws:itemTemplate>
+                <ws:partial template="Controls/list:ItemTemplate"
+                            itemActionsClass="controls-itemActionsV_position_topRight">
+                    <ws:contentTemplate>
+                        <div class="Controls-ItemActionsBackground__transparent-itemContent">
+                            <div class="text">{{itemTemplate.itemData.item.get('title')}}</div>
+                        </div>
+                    </ws:contentTemplate>
+                </ws:partial>
+            </ws:itemTemplate>
+        </Controls.list:View>
+    </div>
+    <div class="Controls-ItemActionsBackground__pink-area">
+        <div>Pink</div>
+        <Controls.list:View
+                name="pinkOptions"
+                itemActionsBackgroundStyle="pink"
+                keyProperty="id"
+                source="{{_viewSource}}"
+                itemActions="{{_itemActions}}">
+        </Controls.list:View>
+    </div>
+    <div class="Controls-ItemActionsBackground__blue-area">
+        <div>Blue</div>
+        <Controls.list:View
+                name="blueOptions"
+                itemActionsBackgroundStyle="blue"
+                keyProperty="id"
+                source="{{_viewSource}}"
+                itemActions="{{_itemActions}}">
+        </Controls.list:View>
+    </div>
+</div>

--- a/Controls-demo/list_new/ItemActions/ItemActionsBackground/ItemActionsBackground.less
+++ b/Controls-demo/list_new/ItemActions/ItemActionsBackground/ItemActionsBackground.less
@@ -1,0 +1,35 @@
+.Controls-ItemActionsBackground__transparent-area {
+  background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc1JyBoZWlnaHQ9JzUnPgo8cmVjdCB3aWR0aD0nNScgaGVpZ2h0PSc1JyBmaWxsPScjZmZmJy8+CjxyZWN0IHdpZHRoPScxJyBoZWlnaHQ9JzEnIGZpbGw9JyNjY2MnLz4KPC9zdmc+") #dad9e0;
+
+  .Controls-ItemActionsBackground__transparent-itemContent {
+    padding-top: 32px;
+  }
+}
+
+.ws-is-hover .Controls-ItemActionsBackground__transparent-area .controls-ListView__item_highlightOnHover_default_theme_default:hover {
+  background-color: transparent;
+}
+
+.Controls-ItemActionsBackground__pink-area {
+  background-color: #fff5f5;
+}
+
+.ws-is-hover .Controls-ItemActionsBackground__pink-area .controls-ListView__item_highlightOnHover_default_theme_default:hover {
+  background-color: snow;
+}
+
+.controls-itemActionsV_style_pink_theme-default {
+  background-color: snow;
+}
+
+.Controls-ItemActionsBackground__blue-area {
+  background-color: #edf4fc;
+}
+
+.ws-is-hover .Controls-ItemActionsBackground__blue-area .controls-ListView__item_highlightOnHover_default_theme_default:hover {
+  background-color: #f6fafe;
+}
+
+.controls-itemActionsV_style_blue_theme-default {
+  background-color: #f6fafe;
+}

--- a/Controls-demo/list_new/ItemActions/ItemActionsVisibility/Onhover/ItemActions.wml
+++ b/Controls-demo/list_new/ItemActions/ItemActionsVisibility/Onhover/ItemActions.wml
@@ -1,4 +1,4 @@
-<div class="controlsDemo__wrapper controlsDemo_fixedWidth500 controlsDemo__itemActions_list_delayed">
+<div class="controlsDemo__wrapper controlsDemo_fixedWidth500 controlsDemo__itemActions_list_onhover">
     <Controls.list:View
             keyProperty="id"
             source="{{_viewSource}}"

--- a/Controls/_itemActions/interface/IItemActionsOptions.ts
+++ b/Controls/_itemActions/interface/IItemActionsOptions.ts
@@ -371,6 +371,16 @@ export interface IItemActionsOptions {
     itemActionVisibilityCallback?: TItemActionVisibilityCallback;
 
     /**
+     * @name Controls/_itemActions/itemActions/interface/IItemActionsOptions#itemActionsBackgroundStyle
+     * @cfg {String} Префикс стиля для настройки фона панели опций записи. По умолчанию фон соответствует цвету фона hovered записи.
+     */
+    /*ENG
+     * @name Controls/_itemActions/itemActions/interface/IItemActionsOptions#itemActionsBackgroundStyle
+     * @cfg {String} Style prefix for configuring item actions panel background. By default it matches hovered item background
+     */
+    itemActionsBackgroundStyle?: string;
+
+    /**
      * @name Controls/_itemActions/itemActions/interface/IItemActionsOptions#itemActionsClass
      * @cfg {String} CSS класс, позволяющий задать отступы и позицию панели с {@link https://wi.sbis.ru/doc/platform/developmentapl/interface-development/controls/list/list/item-actions/ опциями записи} внутри элемента.
      * @default controls-itemActionsV_position_bottomRight

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -2413,6 +2413,10 @@ const _private = {
                 }
             };
         }
+        const style = options.itemActionsBackgroundStyle ||
+            (options.itemActionsVisibility === 'visible' && 'transparent') ||
+            options.style;
+
         // Гарантированно инициализируем шаблоны, если это ещё не произошло
         const itemActionsChangeResult = itemActionsController.update({
                 editingItem: editingItemData,
@@ -2421,7 +2425,7 @@ const _private = {
                 itemActionsProperty: options.itemActionsProperty,
                 visibilityCallback: options.itemActionVisibilityCallback,
                 itemActionsPosition: options.itemActionsPosition,
-                style: options.itemActionsVisibility === 'visible' ? 'transparent' : options.style,
+                style,
                 theme: options.theme,
                 actionAlignment: options.actionAlignment,
                 actionCaptionPosition: options.actionCaptionPosition,


### PR DESCRIPTION
https://online.sbis.ru/doc/3f959853-3241-4d22-8107-1890380c2e4e  Требуется возможность сделать фон опций строки прозрачным или задать ему какой-то конкретный цвет (для случая, когда под опцией строки может оказаться текст .
Примеры на сринах:
Скрин 1 - вообще ховер на строке убираем потому что развернутые ниже календари это часть строки
Скрин 2 и 3 - окно может быть разного цвета (зависит от типа дня - рабочий, выходной, больничный, отпуск, etc...). Тут прозрачностью не отделаться, нужно конкретный цвет что бы блок опций закрыл текст под собой.