### PR TITLE
Документ №1180164251 от 2020-09-21 Тихомиров А.А.

### DIFF
--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -4393,13 +4393,13 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
             return;
         }
         swipeEvent.stopPropagation();
-        const key = item.getContents().getKey();
+        const key = _private.getPlainItemContents(item).getKey();
         const itemContainer = (swipeEvent.target as HTMLElement).closest('.controls-ListView__itemV');
         const swipeContainer = _private.getSwipeContainerSize(itemContainer as HTMLElement);
 
         if (swipeEvent.nativeEvent.direction === 'left') {
             _private.setMarkedKey(this, key);
-            _private.getItemActionsController(this).activateSwipe(item.getContents().getKey(), swipeContainer?.width, swipeContainer?.height);
+            _private.getItemActionsController(this).activateSwipe(key, swipeContainer?.width, swipeContainer?.height);
         }
         if (swipeEvent.nativeEvent.direction === 'right') {
             const swipedItem = _private.getItemActionsController(this).getSwipeItem();
@@ -4424,7 +4424,7 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
 
                 // Animation should be played only if checkboxes are visible.
                 if (this._options.multiSelectVisibility !== 'hidden') {
-                    _private.getItemActionsController(this).activateRightSwipe(item.getContents().getKey());
+                    _private.getItemActionsController(this).activateRightSwipe(key);
                 }
                 _private.setMarkedKey(this, key);
             }

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4598,7 +4598,6 @@ define([
 
       describe('_onItemSwipe()', () => {
          let swipeEvent;
-         let itemData;
          let instance;
 
          function initTest(options) {
@@ -4754,6 +4753,35 @@ define([
                stubCreateSelectionController.restore();
                spySetMarkedKey.restore();
             });
+         });
+
+         // Должен работать свайп по breadcrumbs
+         it('should work with breadcrumbs', () => {
+            swipeEvent = initSwipeEvent('left');
+            initTest();
+            const itemAt0 = instance._listViewModel.at(0);
+            const breadcrumbItem = {
+               '[Controls/_display/BreadcrumbsItem]': true,
+               _$active: false,
+               isSelected: () => true,
+               getContents: () => ['fake', 'fake', 'fake', itemAt0.getContents() ],
+               setActive: function() {
+                  this._$active = true;
+               },
+               getActions: () => ({
+                  all: [{
+                     id: 2,
+                     showType: 0
+                  }]
+               })
+            };
+            const stubActivateSwipe = sinon.stub(instance._itemActionsController, 'activateSwipe')
+               .callsFake((itemKey, actionsContainerWidth, actionsContainerHeight) => {
+                  assert.equal(itemKey, itemAt0.getContents().getKey());
+                  stubActivateSwipe.restore();
+               });
+
+            instance._onItemSwipe({}, breadcrumbItem, swipeEvent);
          });
 
          // Должен правильно рассчитывать ширину для записей списка при отображении опций свайпа


### PR DESCRIPTION
https://online.sbis.ru/doc/197c58c5-8579-4417-ac1a-ffd1f4098a83  Не работает свайп по папам в результатах поиска в реестре в виде дерева
повторить можно в Каталог, Служба поддержки/По видам, Сотрудники/Должности
1. http://usd-comp175:777/Controls-demo/app/Controls-demo%2FExplorer_new%2FSearch%2FIndex
2. искать "canon"
3. свайп влево по первой строке
ФР: свайп не работает
ОР: свайп вправо отмечает чекбокс, свайп влево открывает меню по свайпу