### PR TITLE
Документ №1180171406 от 2020-09-21 Курицын К.А.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -514,9 +514,14 @@ var
             if (!self.isSupportLadder(self._options.ladderProperties)) {
                 return {};
             }
-            if (!self._ladder || self._options.stickyColumn) {
-                self.resetCachedItemData();
-            }
+
+            // Если при перестройке "лесенки" не сбрасывать кеш, то после добавления элементов по месту при скролле
+            // реестра ломается вёрстка, т.к. в span подставляются старые данные.
+            // см. https://online.sbis.ru/opendoc.html?guid=4fe3dd6f-c76b-45fa-b676-5914a896c7c9
+            // Предыдущая реализацию согласно док-там:
+            // см. https://online.sbis.ru/opendoc.html?guid=d3a0a646-9a22-4a61-be98-7c8570c7a295
+            // см. https://online.sbis.ru/opendoc.html?guid=458ac3b7-b899-4fff-8fcf-ae8168b67b80
+            self.resetCachedItemData();
 
             const hasVirtualScroll = !!self._options.virtualScrolling || Boolean(self._options.virtualScrollConfig);
             const displayStopIndex = self.getDisplay() ? self.getDisplay().getCount() : 0;
@@ -530,19 +535,6 @@ var
                 columns: self._options.columns,
                 stickyColumn: self._options.stickyColumn
             });
-            //Нужно сбросить кэш для записей, у которых поменялась конфигурация лесенки
-            if (self._ladder) {
-                for (let i = startIndex; i < stopIndex ; i++) {
-                    if (!isEqual(newLadder.stickyLadder[i], self._ladder.stickyLadder[i]) ||
-                        !isEqual(newLadder.ladder[i], self._ladder.ladder[i])) {
-
-                        const dispItem = self.getItemById(self.getItems()?.at(i)?.getId());
-                        if (dispItem) {
-                            self.resetCachedItemData(self._getDisplayItemCacheKey(dispItem));
-                        }
-                    }
-                }
-            }
             return newLadder;
         },
         getTableCellStyles(currentColumn): string {

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -1518,21 +1518,10 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             assert.equal(4, Object.keys(ladderViewModel._ladder.stickyLadder).length);
             assert.equal(4, Object.keys(ladderViewModel._ladder.ladder).length);
 
-
-            let resetCacheKey = null;
-            let fullCacheReset = false;
-            ladderViewModel.resetCachedItemData = (key) => {
-               if (!key) {
-                  fullCacheReset = true;
-               }
-               resetCacheKey = key;
-            };
             ladderViewModel._model._startIndex = 1;
             ladderViewModel._ladder = gridMod.GridViewModel._private.prepareLadder(ladderViewModel);
             assert.equal(3, Object.keys(ladderViewModel._ladder.stickyLadder).length);
             assert.equal(3, Object.keys(ladderViewModel._ladder.ladder).length);
-            assert.isFalse(fullCacheReset, 'Не должен сбрасываться весь кэш');
-            assert.equal(1, resetCacheKey, 'Неверный id записи со сброшенным кэшем');
          });
       });
       describe('other methods of the class', function() {


### PR DESCRIPTION
https://online.sbis.ru/doc/4fe3dd6f-c76b-45fa-b676-5914a896c7c9  Едет верстка всего реестра при скролле
Как повторить:  
Бизнес/Продажи/Заказы
скрольнуть чуть вниз
скопировать док
сохранить
скролируем вверх до упора.(должны быть доки бедующей даты)
ФР:  
едет верстка всего реестра
ОР:  
верстка не едет. реестр цел и не вредим 
Страница: Счета/Заказы/СБИС
Логин: аргус1 Пароль: Аргус123  
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36
Версия:
online-inside_20.6100 (ver 20.6100) - 867 (21.09.2020 - 14:00:00)
Platforma 20.6100 - 82 (21.09.2020 - 10:38:31)
WS 20.6100 - 74 (21.09.2020 - 12:43:16)
Types 20.6100 - 61 (21.09.2020 - 11:41:15)
CONTROLS 20.6100 - 84 (21.09.2020 - 11:30:16)
SDK 20.6100 - 356 (21.09.2020 - 13:30:15)
DISTRIBUTION: ext
GenerateDate: 21.09.2020 - 14:00:00
autoerror_sbislogs 21.09.2020