### PR TITLE
Документ №1180175321 от 2020-09-22 Колотушкина А.Е.

### DIFF
--- a/Controls/_grid/GridView.ts
+++ b/Controls/_grid/GridView.ts
@@ -286,9 +286,10 @@ var
                     // перерисовывается с новым набором колонок, но со старыми данными. Пример ошибки:
                     // https://online.sbis.ru/opendoc.html?guid=91de986a-8cb4-4232-b364-5de985a8ed11
                     self._doAfterReload(() => {
-                        // Если не идет перезагрузка и мы обновляемся, то не нужно поднимать версию модели.
-                        // Колонки - реактивное состояние таблицы, они вызывают перерисовку.
-                        self._listModel.setColumns(newOptions.columns, !self._reloadInProgress);
+                        // Если колонки изменились, например, их кол-во, а данные остались те же, то
+                        // то без перерисовки мы не можем корректно отобразить данные в новых колонках.
+                        // правка конфликтует с https://online.sbis.ru/opendoc.html?guid=a8429971-3a3c-44d0-8cca-098887c9c717
+                        self._listModel.setColumns(newOptions.columns, false);
                     });
                 } else {
                     self._listModel.setColumns(newOptions.columns);


### PR DESCRIPTION
https://online.sbis.ru/doc/737be750-497d-4a62-beb2-80a387274402  Сдано | Не сдано. Едет верстка таблицы при закрытии/открытии ленты ЦУ
Как повторить:  
https://test-online.sbis.ru/ereportSummary/ (fakel/Qwerty123)
Открыть/закрыть ленту ЦУ
ФР:  
Список организаций пропадает, иконки в таблице тоже
ОР:  
Все ок
Страница: Сдано | не сдано/СБИС
Логин: fakel Пароль:   
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36
Версия:
online-inside_20.6100 (ver 20.6100) - 873 (22.09.2020 - 00:00:01)
Platforma 20.6100 - 85 (21.09.2020 - 22:38:30)
WS 20.6100 - 77 (21.09.2020 - 21:43:14)
Types 20.6100 - 64 (21.09.2020 - 20:41:13)
CONTROLS 20.6100 - 87 (21.09.2020 - 20:30:13)
SDK 20.6100 - 370 (21.09.2020 - 23:41:31)
DISTRIBUTION: ext
GenerateDate: 22.09.2020 - 00:00:01
autoerror_sbislogs 22.09.2020