### PR TITLE
Документ №1180190971 от 2020-09-23 Кречетова Е.Т.

### DIFF
--- a/Controls/_explorer/View.ts
+++ b/Controls/_explorer/View.ts
@@ -646,10 +646,11 @@ var
 
          if (shouldHandleClick) {
               const nodeType = item.get(this._options.nodeProperty);
+              const isSearchMode = this._viewMode === 'search';
 
               // Проваливание возможно только в узел (ITEM_TYPES.node).
               // Проваливание невозможно, если по клику следует развернуть узел/скрытый узел.
-              if ((this._options.expandByItemClick && nodeType !== ITEM_TYPES.leaf) || (nodeType !== ITEM_TYPES.node)) {
+              if ((!isSearchMode && this._options.expandByItemClick && nodeType !== ITEM_TYPES.leaf) || (nodeType !== ITEM_TYPES.node)) {
                   return res;
               }
 

--- a/tests/ControlsUnit/Explorer/Explorer.test.js
+++ b/tests/ControlsUnit/Explorer/Explorer.test.js
@@ -703,6 +703,45 @@ define([
             assert.equal(rootBefore, explorer._root);
          });
 
+         it('should open node by item click with option expandByItemClick in search mode', () => {
+            const cfg = {
+               editingConfig: {},
+               expandByItemClick: true,
+               nodeProperty: 'node@'
+            };
+            const explorer = new explorerMod.View(cfg);
+            explorer.saveOptions(cfg);
+            explorer._viewMode = 'search';
+            explorer._restoredMarkedKeys = {
+               null: {
+                  markedKey: null
+               }
+            };
+            const rootBefore = explorer._root;
+            explorer._children = {
+               treeControl: {
+                  _children: {
+
+                  },
+                  commitEdit: () => ({
+                     addCallback(callback) {
+                        callback();
+                        assert.notEqual(rootBefore, explorer._root);
+                     }
+                  })
+               }
+            };
+            const event = { stopPropagation: () => {} };
+            const clickEvent = {
+               target: {closest: () => {}}
+            };
+            const item = {
+               get: () => true,
+               getId: () => 'itemId'
+            };
+            assert.doesNotThrow(() => { explorer._onItemClick(event, item, clickEvent) });
+         });
+
          it('_onItemClick', async function() {
             isNotified = false;
             isWeNotified = false;


### PR DESCRIPTION
https://online.sbis.ru/doc/0053292d-6215-464f-bf66-d9ce17c2032f  ПРИЕМОЧНЫЕ автотесты. Эквайринг: Консольная ошибка при клике на название НО при поиске в реестре договоров
Как повторить:  
Авторизоваться адскийпесик/адскийпесик123
Учет/ДЕньги/Экварйинг
Провалиться в реестр Договоры
В поле поиска ввести Компания
Кликнуть на название организации
ФР:  
Ничего не происходит
Валится консоль hooks.js:636 CONTROL ERROR:  Event handle: "itemclick" IN "Controls/tree:TreeControl"
ОР:  
раскрывается узел 
Если это невозможно, то организация не должна быть кликабельная
Страница: Эквайринг/СБИС
Логин: адскийпесик Пароль: адскийпесик123  
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36
Версия:
online-inside_20.6100 (ver 20.6100) - 891 (23.09.2020 - 14:00:00)
Platforma 20.6100 - 92 (23.09.2020 - 11:51:07)
WS 20.6100 - 85 (23.09.2020 - 12:43:15)
Types 20.6100 - 71 (23.09.2020 - 11:41:11)
CONTROLS 20.6100 - 96 (23.09.2020 - 11:30:16)
SDK 20.6100 - 408 (23.09.2020 - 13:50:17)
DISTRIBUTION: ext
GenerateDate: 23.09.2020 - 14:00:00
autoerror_sbislogs 23.09.2020