### PR TITLE
Документ №1180200085 от 2020-09-24 Смирнов А.А.

### DIFF
--- a/tests/ControlsUnit/Explorer/Explorer.test.js
+++ b/tests/ControlsUnit/Explorer/Explorer.test.js
@@ -729,7 +729,8 @@ define([
                         callback();
                         assert.notEqual(rootBefore, explorer._root);
                      }
-                  })
+                  }),
+                  getEditingItem: () => {}
                }
             };
             const event = { stopPropagation: () => {} };


### PR DESCRIPTION
https://online.sbis.ru/doc/e3f76de6-7d12-428a-b60f-9950889df558  Platforma_UI_20.7000_tests - ошибка юнит-теста
ontrolsUnit_node.Controls Explorer _notify(rootChanged).should open node by item click with option expandByItemClick in search mode (from Mocha Tests)
Стек вызовов
expected [Function] to not throw an error but 'TypeError: this._children.treeControl.getEditingItem is not a function' was thrown
AssertionError: expected [Function] to not throw an error but 'TypeError: this._children.treeControl.getEditingItem is not a function' was thrown
    at Context.<anonymous> (/home/sbis/workspace/Platforma_UI_20.7000_tests/stand/build-ui/resources/ControlsUnit/Explorer/Explorer.test.js:743:20)
    at processImmediate (internal/timers.js:456:21)
http://platform-jenkins.sbis.ru/user/aa.smirnov2/my-views/view/%D0%9E%D1%81%D1%82%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B5%20%D0%BA%D0%BE%D0%BC%D0%BF%D0%BE%D0%BD%D0%B5%D0%BD%D1%82%D1%8B/job/Platforma_UI_20.7000_tests/261/testReport/junit/ControlsUnit_node/Controls%20Explorer%20_notify(rootChanged)/should_open_node_by_item_click_with_option_expandByItemClick_in_search_mode/