### PR TITLE
Документ №1180158384 от 2020-09-18 Колотухин И.О.

### DIFF
--- a/Controls-demo/Explorer_new/Search/Search.wml
+++ b/Controls-demo/Explorer_new/Search/Search.wml
@@ -5,7 +5,7 @@
                                  on:click="_updateStartingWith()" attr:style="padding: 0 5px"/>
     </div>
     <Controls.list:DataContainer source="{{_viewSource}}" keyProperty="id" bind:filter="_filter">
-        <Controls.search:Controller searchParam="title" minSearchLength="{{3}}" startingWith="{{_startingWith}}">
+        <Controls.search:Controller searchParam="title" minSearchLength="{{3}}" searchStartingWith="{{_startingWith}}">
             <div class="ws-fragment">
                 <Controls.search:InputContainer>
                     <Controls.search:Input/>

--- a/Controls/_list/Controllers/MoveController.ts
+++ b/Controls/_list/Controllers/MoveController.ts
@@ -137,9 +137,9 @@ export class MoveController {
      */
     private _openMoveDialog(selection: ISelectionObject, filter?: TFilterObject): Promise<void> {
         const templateOptions: IMoverDialogTemplateOptions = {
-            ...(this._popupOptions.templateOptions as IMoverDialogTemplateOptions),
             movedItems: selection.selected,
-            source: this._source
+            source: this._source,
+            ...(this._popupOptions.templateOptions as IMoverDialogTemplateOptions)
         };
 
         return new Promise((resolve) => {

--- a/Controls/_list/Mover.ts
+++ b/Controls/_list/Mover.ts
@@ -343,9 +343,9 @@ var _private = {
 
     openMoveDialog(self, selection): Promise<void> {
         const templateOptions: IMoverDialogTemplateOptions = {
-            ...(self._moveDialogOptions as IMoverDialogTemplateOptions),
             movedItems: _private.useController(selection) ? selection.selectedKeys : _private.prepareMovedItems(self, selection),
-            source: self._source
+            source: self._source,
+            ...(self._moveDialogOptions as IMoverDialogTemplateOptions)
         };
         return new Promise((resolve) => {
             Dialog.openPopup({

--- a/tests/ControlsUnit/List/Controllers/MoveController.test.ts
+++ b/tests/ControlsUnit/List/Controllers/MoveController.test.ts
@@ -186,6 +186,34 @@ describe('Controls/list_clean/MoveController', () => {
                 });
         });
 
+        // Если при перемещении методом moveWithDialog() в popupOptions.templateOptions передан source,
+        // то он используется в диалоге перемещения вместо source, переданного в контроллер
+        it('moveWithDialog() + source set within popupOptions.templateOptions object', () => {
+            const source2: Memory = new Memory({
+                keyProperty: 'id',
+                data: clone(data)
+            });
+            // to prevent popup open
+            const stubDialog = stub(Dialog, 'openPopup').callsFake((args) => {
+                assert.notEqual((args.templateOptions as {source: Memory}).source, source);
+                assert.equal((args.templateOptions as {source: Memory}).source, source2);
+                return Promise.resolve(args.eventHandlers.onResult(createFakeModel(data[3])));
+            });
+            cfg.popupOptions.templateOptions = {
+                ...cfg.popupOptions.templateOptions as object,
+                source: source2
+            }
+            controller = new MoveController(cfg);
+            return resolveMoveWithDialog(controller, selectionObject, {myProp: 'test'})
+                .then((result: boolean) => {
+
+                    // Ожидаю. что перемещение произойдёт успешно, т.к. все условия соблюдены
+                    sinonAssert.notCalled(stubLoggerError);
+                    assert.isTrue(result);
+                    stubDialog.restore();
+                });
+        });
+
         // Передан popupOptions без template при перемещении методом moveWithDialog()
         it('moveWithDialog() + popupOptions.template is not set', () => {
             // to prevent popup open


### PR DESCRIPTION
https://online.sbis.ru/doc/f76ae23a-3405-4765-8884-49913aed6413  После внесения изменения в метод openMoveDialog
https://github.com/saby/wasaby-controls/commit/294cccd8d9f3d3ed06db2128284cb731c60e621e
Для отображения объектов  в окне перемещения стал использоваться сорс не из опции
moveDialogTemplate.