### PR TITLE
Документ №1180247760 от 2020-10-01 Родионов Е.А.

### DIFF
--- a/Controls/_itemActions/resources/templates/ItemActionsTemplate.wml
+++ b/Controls/_itemActions/resources/templates/ItemActionsTemplate.wml
@@ -30,9 +30,9 @@
 <!-- TODO moved to Grid/Item.wml after complete task: https://online.sbis.ru/opendoc.html?guid=d473668a-3c9a-43b9-a59c-b994cbf873bd -->
 <ws:if data="{{!!itemActionsContainerStyles}}">
     <div class="controls-itemActionsV__container" style="{{itemActionsContainerStyles}}">
-        <ws:partial template="localItemActionsTemplate"/>
+        <ws:partial template="localItemActionsTemplate" itemData="{{item || itemData}}"/>
     </div>
 </ws:if>
 <ws:else>
-    <ws:partial template="localItemActionsTemplate"/>
+    <ws:partial template="localItemActionsTemplate" itemData="{{item || itemData}}"/>
 </ws:else>


### PR DESCRIPTION
https://online.sbis.ru/doc/05e85bbd-06ac-4430-a4b2-548f9c4104e1  В шаблоне Controls/_itemActions/resources/templates/ItemActionsTemplate.wml:14
Нужно заменить itemData на (item || itemData).
Это временная конструкция при переходе на новую модель. Мы сами переходим с itemData на item, а прикладники все еще перепрокидывают опцию. мы им отдаем item как itemData, они нам снова itemData. объект один и тот же, но названия разные. Надо поддержать