### PR TITLE
Документ №1180267286 от 2020-10-05 Оследкин М.С.

### DIFF
--- a/Controls/_list/Remover.ts
+++ b/Controls/_list/Remover.ts
@@ -42,13 +42,11 @@ var _private = {
         return Promise.resolve(afterItemsRemoveResult);
     },
 
-    updateDataOptions: function (self, dataOptions) {
-        if (dataOptions) {
-            self._items = dataOptions.items;
-            self._source = dataOptions.source;
-            self._filter = dataOptions.filter;
-            self._keyProperty = dataOptions.keyProperty;
-        }
+    updateDataOptions: function (self, newOptions, contextDataOptions) {
+        self._keyProperty = newOptions.keyProperty ? newOptions.keyProperty : contextDataOptions.keyProperty;
+        self._items = newOptions.items ? newOptions.items : contextDataOptions.items;
+        self._source = newOptions.source ? newOptions.source : contextDataOptions.source;
+        self._filter = newOptions.filter ? newOptions.filter : contextDataOptions.filter;
     },
 
     getItemsBySelection(self, items): Promise<CrudEntityKey[]> {
@@ -95,11 +93,11 @@ var _private = {
 
 var Remover = BaseAction.extend({
     _beforeMount: function (options, context) {
-        _private.updateDataOptions(this, options);
+        _private.updateDataOptions(this, options, context.dataOptions);
     },
 
     _beforeUpdate: function (options, context) {
-        _private.updateDataOptions(this, options);
+        _private.updateDataOptions(this, options, context.dataOptions);
     },
 
     removeItems(items: string[]): Promise<void> {


### PR DESCRIPTION
https://online.sbis.ru/doc/89525506-eaec-4be4-b56d-34ec8d2a450a  Подбор персонала. Ошибки в консоли и НЕвозможно удалить событие и вакансию в карточке кандидата. 
Как повторить:  
1. Сотрудники- подбор персонала- кандидаты- карточка кандидата- блок события
2. Навести по ховеру на строку события- кликнуть кнопку доп.меню - удалить событие (тоже самое с вакансией)
ФР:  
Событие и вакансия не удаляются , в консоли появляется ошибка. (см. логи и видео)
ОР:  
События и вакансии удаляются из карточки кандидата без ошибок.
Страница: Кандидаты
Логин: osledkin Пароль: qwerty123  
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36
Версия:
online-inside_20.7100 (ver 20.7100) - 485 (05.10.2020 - 08:00:00)
Platforma 20.7000 - 320 (05.10.2020 - 06:50:03)
WS 20.7000 - 813 (05.10.2020 - 05:51:53)
Types 20.7000 - 813 (05.10.2020 - 05:51:53)
CONTROLS 20.7000 - 813 (05.10.2020 - 05:51:53)
SDK 20.7000 - 918 (05.10.2020 - 07:52:12)
DISTRIBUTION: ext
GenerateDate: 05.10.2020 - 08:00:00
autoerror_sbislogs 05.10.2020