### PR TITLE
Документ №1180258377 от 2020-10-02 Авраменко А.С.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -375,15 +375,15 @@ export class Controller {
                 }
             }
         };
-        if (this._collection.isEventRaising()) {
-            this._collection.setEventRaising(false, true);
+        if (this._isEventRaising()) {
+            this._setEventRaising(false, true);
         }
         this._collection.each(assignActionsOnItem);
         if (editingItem) {
             assignActionsOnItem(editingItem);
         }
-        if (!this._collection.isEventRaising()) {
-            this._collection.setEventRaising(true, true);
+        if (!this._isEventRaising()) {
+            this._setEventRaising(true, true);
         }
         this._collection.setActionsAssigned(true);
 
@@ -429,6 +429,16 @@ export class Controller {
             ));
         }
         return [];
+    }
+
+    private _isEventRaising() {
+        return this._collection.isEventRaising ? this._collection.isEventRaising() : false
+    }
+
+    private _setEventRaising(enabled: boolean, analyze: boolean): void {
+        if(this._collection.setEventRaising) {
+            this._collection.setEventRaising(enabled, analyze);
+        }
     }
 
     /**

--- a/Controls/_itemActions/interface/IItemActionsCollection.ts
+++ b/Controls/_itemActions/interface/IItemActionsCollection.ts
@@ -1,6 +1,7 @@
 import {IBaseCollection, ISwipeConfig, ANIMATION_STATE} from 'Controls/display';
 import {IItemActionsItem} from './IItemActionsItem';
 import {IItemActionsTemplateConfig} from './IItemActionsTemplateConfig';
+import {EventRaisingMixin} from 'Types/collection';
 
 /**
  * Интерфейс коллекции, элементы которой обладают опциями записи
@@ -15,7 +16,7 @@ import {IItemActionsTemplateConfig} from './IItemActionsTemplateConfig';
  * @public
  * @author Аверкиев П.А.
  */
-export interface IItemActionsCollection extends IBaseCollection<IItemActionsItem> {
+export interface IItemActionsCollection extends IBaseCollection<IItemActionsItem>, Partial<EventRaisingMixin> {
     // '[Controls/_itemActions/interface/IItemActionsCollection]': true;
 
     /**


### PR DESCRIPTION
https://online.sbis.ru/doc/30fbc41f-c36a-4ab8-8770-f0d011f4e05d  canban.model не должна реализовывать setEventRaising/getEventRaising, вместо этого достаточно добавить проверку в itemActionController'e