### PR TITLE
Документ №1180400363 от 2020-10-23 Поздняков А.М.

### DIFF
--- a/Controls-demo/List/ItemActions.ts
+++ b/Controls-demo/List/ItemActions.ts
@@ -60,7 +60,7 @@ const itemActions: IItemAction[] = [
       parent: null,
       'parent@': true,
       handler(model: Model): void {
-         alert('Message Click');
+         IoC.resolve('ILogger').info('action message Click ', model);
       }
    },
    {

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -4974,7 +4974,7 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
     _onItemActionsMenuResult(eventName: string, actionModel: Model, clickEvent: SyntheticEvent<MouseEvent>): void {
         if (eventName === 'itemClick') {
             const action = actionModel && actionModel.getRawData();
-            if (action && !action['parent@']) {
+            if (action) {
                 const item = _private.getItemActionsController(this, this._options).getActiveItem();
                 _private.handleItemActionClick(this, action, clickEvent, item, true);
             }

--- a/Controls/_listRender/View.ts
+++ b/Controls/_listRender/View.ts
@@ -337,7 +337,7 @@ export default class View extends Control<IViewOptions> {
         clickEvent: SyntheticEvent<MouseEvent>): void {
         if (eventName === 'itemClick') {
             const action = actionModel && actionModel.getRawData();
-            if (action && !action['parent@']) {
+            if (action) {
                 const item = this._itemActionsController.getActiveItem();
                 this._handleItemActionClick(action, clickEvent, item, true);
             }

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4708,6 +4708,24 @@ define([
             assert.equal(outgoingEventsMap.actionClick[2].className, 'controls-ListView__itemV');
          });
 
+         // Клик по itemAction с подменю ('parent@': true) должен бросать событие actionClick
+         it('should emit actionClick event on submenu (\'parent@\': true) action click', async () => {
+            const fakeEvent2 = initFakeEvent();
+            const stubHandleItemActionClick = sinon.stub(lists.BaseControl._private, 'handleItemActionClick');
+            const actionModel = {
+               getRawData: () => ({
+                  id: 2,
+                  showType: 0,
+                  parent: 1,
+                  'parent@': true
+               })
+            };
+            instance._listViewModel.setActiveItem(instance._listViewModel.at(0));
+            instance._onItemActionsMenuResult('itemClick', actionModel, fakeEvent2);
+            sinon.assert.called(stubHandleItemActionClick);
+            stubHandleItemActionClick.restore();
+         });
+
          // должен открывать меню, соответствующее новому id Popup
          it('should open itemActionsMenu according to its id', () => {
             const fakeEvent = initFakeEvent();


### PR DESCRIPTION
https://online.sbis.ru/doc/39562ea7-2dbf-4526-ac23-a77f4f4af50f  Прошу доработать поведение Controls/menu:
Сейчас, если для пункта меню указан parent@ = true, то при клике на него не стреляет событие actionClick.
Для реализации надзадачи, необходима возможность обрабатывать клик для пункта меню с parent@ = true