### PR TITLE
Документ №1180460491 от 2020-11-02 Замолотчикова А.М.

### DIFF
--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -5024,7 +5024,9 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
      * @private
      */
     _onItemActionsMenuClose(currentPopup): void {
-        _private.closeActionsMenu(this, currentPopup);
+        if (!this._listViewModel.isDestroyed()) {
+            _private.closeActionsMenu(this, currentPopup);
+        }
     },
 
     _itemMouseDown(event, itemData, domEvent) {

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -5024,7 +5024,7 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
      * @private
      */
     _onItemActionsMenuClose(currentPopup): void {
-        if (!this._listViewModel.isDestroyed()) {
+        if (!this._destroyed) {
             _private.closeActionsMenu(this, currentPopup);
         }
     },

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4930,6 +4930,15 @@ define([
             assert.equal(instance._itemActionsMenuId, null);
          });
 
+         // Необходимо игнорировать заурытие меню, если инстанс был разрушен
+         it('should close popup with specified id', () => {
+            const spyCloseActionsMenu = sinon.spy(lists.BaseControl._private, 'closeActionsMenu');
+            instance.destroy();
+            instance._onItemActionsMenuClose({id: 'ekaf'});
+            sinon.assert.notCalled(spyCloseActionsMenu);
+            spyCloseActionsMenu.restore();
+         });
+
          // Необходимо показать контекстное меню по longTap, если не был инициализирован itemActionsController
          it('should display context menu on longTap', () => {
             const spyOpenContextMenu = sinon.spy(lists.BaseControl._private, 'openContextMenu');

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4931,7 +4931,7 @@ define([
          });
 
          // Необходимо игнорировать заурытие меню, если инстанс был разрушен
-         it('should close popup with specified id', () => {
+         it('should not call closeActionsMenu when control is destroyed', () => {
             const spyCloseActionsMenu = sinon.spy(lists.BaseControl._private, 'closeActionsMenu');
             instance.destroy();
             instance._onItemActionsMenuClose({id: 'ekaf'});


### PR DESCRIPTION
https://online.sbis.ru/doc/b24601cf-af4e-4c66-bc0b-40a572a3a063  Конфигурация в Настройках
Ошибка в консоль при закрытии списка конфигураций по клику за пределами списка, если у конфигурации открыто меню по ховеру
CONTROL ERROR:  В окне с шаблоном Controls/menu:Popup произошла ошибка в обработчике события onClose Stack: ReferenceError: This class instance is destroyed.
Как воспроизвести:
1. https://test-online.sbis.ru/ (ДемоРасш/Демо123)
2. Настройки, клик по конфигурации
3. Навести курсор на конфигурация, открыть меню по ховеру
4. Закрыть список конфигураций кликом за пределами списка
ФР:
Ошибка в консоль
CONTROL ERROR:  В окне с шаблоном Controls/menu:Popup произошла ошибка в обработчике события onClose Stack: ReferenceError: This class instance is destroyed.
ОР:
Ошибок нет