### PR TITLE
Документ №1180566819 от 2020-11-17 Сысуева А.Ю.

### DIFF
--- a/Controls/_display/Tree.ts
+++ b/Controls/_display/Tree.ts
@@ -637,7 +637,8 @@ export default class Tree<S, T extends TreeItem<S> = TreeItem<S>> extends Collec
             hasItem = enumerator[method]();
             nearbyItem = enumerator.getCurrent();
 
-            if (skipGroups && nearbyItem['[Controls/_display/GroupItem]']) {
+            // если мы пришли сюда, когда в enumerator ещё ничего нет, то nearbyItem будет undefined
+            if (skipGroups && !!nearbyItem && nearbyItem['[Controls/_display/GroupItem]']) {
                 nearbyItem = undefined;
                 continue;
             }


### PR DESCRIPTION
https://online.sbis.ru/doc/6e75b49c-a0e3-4ed2-9e2c-0bb66ab8e854  ПРИЕМОЧНЫЕ автотесты. Ошибки в консоли при клике на раздел в прайсе престо
Как повторить:
1. престо/каталог/меню
2. кликнуть на название раздела
ФР:  ошибки в консоли. + при попытке добавить номенклатуру бесконечная ромашка
ОР:  ошибок в консоли нет
Страница: Presto/СБИС
Логин: presto_admin Пароль: presto_admin123
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
Версия:
online-inside_20.7100 (ver 20.7100) - 1108 (16.11.2020 - 13:57:07)
Platforma 20.7100 - 133 (16.11.2020 - 10:34:27)
WS 20.7100 - 387 (16.11.2020 - 12:28:56)
Types 20.7100 - 387 (16.11.2020 - 12:28:56)
CONTROLS 20.7100 - 387 (16.11.2020 - 12:28:56)
SDK 20.7100 - 387 (16.11.2020 - 13:08:51)
DISTRIBUTION: ext-pilot
GenerateDate: 16.11.2020 - 13:57:07
autoerror_sbislogs 17.11.2020