### PR TITLE
Документ №1180585477 от 2020-11-18 Мишкорез В.Н.

### DIFF
--- a/Controls/_list/Mover.ts
+++ b/Controls/_list/Mover.ts
@@ -329,11 +329,8 @@ var _private = {
             ...(self._moveDialogOptions as IMoverDialogTemplateOptions)
         };
         return new Promise((resolve) => {
-            Dialog.openPopup({
-                opener: self,
+            self._children.dialogOpener.open({
                 templateOptions,
-                closeOnOutsideClick: true,
-                template: self._moveDialogTemplate,
                 eventHandlers: {
                     onResult: (target: Model) => {
                         resolve(self.moveItems(selection, target, LOCAL_MOVE_POSITION.On))

--- a/Controls/_list/Mover/Mover.wml
+++ b/Controls/_list/Mover/Mover.wml
@@ -1,1 +1,4 @@
-<div></div>
+<Controls.popup:Dialog name="dialogOpener"
+                       closeOnOutsideClick="{{true}}"
+                       template="{{_moveDialogTemplate}}">
+</Controls.popup:Dialog>

--- a/tests/ControlsUnit/List/Mover.test.js
+++ b/tests/ControlsUnit/List/Mover.test.js
@@ -65,6 +65,9 @@ define([
          mover._items = cfg.items;
          mover._source = cfg.source;
          mover._keyProperty = cfg.keyProperty;
+         mover._children.dialogOpener = {
+            open: () => {}
+         };
       });
 
       afterEach(function() {
@@ -151,7 +154,7 @@ define([
 
          it('moveItemsWithDialog', function(done) {
             const items = [1, 2, 3];
-            const stubOpenPopup = sinon.stub(popup.Dialog, 'openPopup');
+            const stubOpenPopup = sinon.stub(mover._children.dialogOpener, 'open');
 
             // @ts-ignore
             stubOpenPopup.callsFake((openArgs) => {
@@ -171,7 +174,7 @@ define([
          it('beforeItemsMove first param should be array of item id\'s', function(done) {
             let movedItems;
             let item = recordSet.at(0);
-            const stubOpenPopup = sinon.stub(popup.Dialog, 'openPopup')
+            const stubOpenPopup = sinon.stub(mover._children.dialogOpener, 'open')
                .callsFake((openArgs) => Promise.resolve(openArgs.eventHandlers.onResult(recordSet.at(1))));
             mover._notify = (event, args) => {
                if (event === 'beforeItemsMove') {
@@ -196,7 +199,7 @@ define([
                }
             };
             let moveItemsCalled = false;
-            const stubOpenPopup = sinon.stub(popup.Dialog, 'openPopup');
+            const stubOpenPopup = sinon.stub(mover._children.dialogOpener, 'open');
 
             // @ts-ignore
             stubOpenPopup.callsFake((openArgs) => {
@@ -229,7 +232,7 @@ define([
                searchParam: 'searchValue'
             };
             const config = {...cfg, searchParam: 'searchParam', filter};
-            const stubOpenPopup = sinon.stub(popup.Dialog, 'openPopup');
+            const stubOpenPopup = sinon.stub(mover._children.dialogOpener, 'open');
             stubLogger = sinon.stub(ui.Logger, 'warn');
             mover._beforeUpdate(config, { dataOptions: config });
             stubLogger.restore();
@@ -267,7 +270,7 @@ define([
             stubLogger = sinon.stub(ui.Logger, 'warn');
             lists.Mover._private.updateDataOptions(mover, config, config);
             stubLogger.restore();
-            const stubOpenPopup = sinon.stub(popup.Dialog, 'openPopup');
+            const stubOpenPopup = sinon.stub(mover._children.dialogOpener, 'open');
 
             // @ts-ignore
             stubOpenPopup.callsFake((openArgs) => {
@@ -323,7 +326,7 @@ define([
 
          it('moveItemsWithDialog with empty items', (done) => {
             const items = [];
-            const spyOpenPopup = sinon.spy(popup.Dialog, 'openPopup');
+            const spyOpenPopup = sinon.spy(mover._children.dialogOpener, 'open');
             const stubOpenConfirmation = sinon.stub(popup.Confirmation, 'openPopup');
             // @ts-ignore
             stubOpenConfirmation.callsFake((args) => {
@@ -339,7 +342,7 @@ define([
 
          it('moveItemsWithDialog for models', (done) => {
             const movedItems = [1, 2, 3];
-            const stubOpenPopup = sinon.stub(popup.Dialog, 'openPopup');
+            const stubOpenPopup = sinon.stub(mover._children.dialogOpener, 'open');
 
             // @ts-ignore
             stubOpenPopup.callsFake((openArgs) => {


### PR DESCRIPTION
https://online.sbis.ru/doc/385c9a1b-c6f1-4640-9cbb-c939ca226a4d  Пропала возможность навесить кастомный класс на диалог перемещения, раньше указывали
 у moveDialogTemplate, в итоге встает на какой-то пустой div.
На скринах как было и как стало.