### PR TITLE
Документ №1180579465 от 2020-11-18 Яковлева А.А.

### DIFF
--- a/Controls/_list/ItemTemplate.wml
+++ b/Controls/_list/ItemTemplate.wml
@@ -39,6 +39,7 @@
     <ws:if data="{{ (item || itemData).hasVisibleActions() || (item || itemData).isEditing() }}">
         <ws:if data="{{ (item || itemData).isSwiped() && itemActionsPosition !== 'outside' }}">
             <ws:partial template="{{ swipeTemplate }}"
+                        itemData="{{itemData}}"
                         highlightOnHover="{{ highlightOnHover }}" />
         </ws:if>
         <ws:else data="{{ itemActionsPosition !== 'custom' }}">


### PR DESCRIPTION
https://online.sbis.ru/doc/b6937185-3d24-4a04-98b4-a1045a187819  iPad по свайпу на новости в ленте не появляются опции 
Как:
1) https://pre-test-online.sbis.ru/
Vrednaya/123456Vred
2) Главная, свайп по новости
ФР: ничего не происходит
ОР: появляется выезжающее меню на новости