### PR TITLE
Документ №1180281078 от 2020-10-06 Соколова Д.А.

### DIFF
--- a/Controls/_list/ListViewModel.ts
+++ b/Controls/_list/ListViewModel.ts
@@ -220,7 +220,9 @@ const ListViewModel = ItemsViewModel.extend([entityLib.VersionableMixin], {
         itemsModelCurrent.multiSelectClassList = itemsModelCurrent.hasMultiSelect ?
             _private.getMultiSelectClassList(itemsModelCurrent, this._options.multiSelectVisibility === 'onhover') : '';
         itemsModelCurrent.calcCursorClasses = this._calcCursorClasses;
-        itemsModelCurrent.backgroundStyle = this._options.backgroundStyle || this._options.style;
+        // Из Controls/scroll:Container прилетает backgroundStyle='default', нужно применять его только если style тоже default
+        itemsModelCurrent.backgroundStyle = this._options.style === 'default' && this._options.backgroundStyle ? this._options.backgroundStyle : this._options.style;
+
         itemsModelCurrent.hoverBackgroundStyle = this._options.hoverBackgroundStyle || this._options.style;
         if (itemsModelCurrent.isGroup) {
             itemsModelCurrent.isStickyHeader = this._options.stickyHeader;


### PR DESCRIPTION
https://online.sbis.ru/doc/f79c6f8a-5610-49e2-b442-928566f78512  Edge, IE11 на Win7, Yandex на WinXP / Двухколоночный реестр
В левом реестре активные папки выделяются как по ховеру
Как повторить:
Контакты - Группы - вкладка "Группы"
https://test-online.sbis.ru/groups-list/tab/groups/
Задачи - Кайдзен - вкладка "Проверки"
https://test-online.sbis.ru/kaizen/tab/checks/
Бизнес - Транспорт - вкладка "Доставки"
https://test-online.sbis.ru/business/transport/tab/deliveries/
Сотрудники - вкладка "Должности"
https://test-online.sbis.ru/staff/tab/posts/
Документы - Входящие
https://test-online.sbis.ru/Documents/registry/Incoming/
Демо_тензор / Демо123
ФР: Папки выглядят как по ховеру (с белой полосой)
ОР: Белая полоса у папки появляется только при наведении
подключение к удал.раб.столу для IE11: tf-stand35; логин: tf-stand35\admin ; пароль:111111
подключение к удал.раб.столу для Yandex: tf-stand52; administrator/123QWEasd