### PR TITLE
Документ №1180590418 от 2020-11-19 Грамотеев Д.А.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -2524,8 +2524,10 @@ var
          * Обновляет стиль фона фиксированных элемекнтов
          * @param backgroundStyle
          */
-        setBackgroundStyle(backgroundStyle) {
-            this._options.backgroundStyle = backgroundStyle;
+        setBackgroundStyle(backgroundStyle): void {
+            if (this._model) {
+                this._model.setBackgroundStyle(backgroundStyle);
+            }
         }
 
     });

--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1702,7 +1702,7 @@ var
             current.getVersion = function() {
                 return self._calcItemVersion(current.item, current.key, current.index);
             };
-            
+
             current.shouldDrawLadderContent = (stickyProperty: string, ladderProperty: string) => {
                 if (!self._options.itemsDragNDrop && current.stickyProperties && self._ladder.stickyLadder[current.index]) {
                     const index = current.stickyProperties.indexOf(stickyProperty);
@@ -2520,11 +2520,19 @@ var
 
         goToNextColgroupColumn(): void {
             this._curColgroupColumnIndex++;
-        }
+        },
 
         // endregion Colgroup columns
 
         // endregion Table Layout
+
+        /**
+         * Обновляет стиль фона фиксированных элемекнтов
+         * @param backgroundStyle
+         */
+        setBackgroundStyle(backgroundStyle) {
+            this._options.backgroundStyle = backgroundStyle;
+        }
 
     });
 

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -1698,7 +1698,7 @@ const _private = {
                     const collectionStartIndex = self._listViewModel.getStartIndex();
                     let result = null;
                     switch (action) {
-                        case IObservable.ACTION_ADD: 
+                        case IObservable.ACTION_ADD:
                             // TODO: this._batcher.addItems(newItemsIndex, newItems)
                             if (self._addItemsDirection) {
                                 self._addItems.push(...newItems);
@@ -1709,13 +1709,13 @@ const _private = {
                             }
                             break;
                         case IObservable.ACTION_MOVE:
-                            result = self._scrollController.handleMoveItems(newItemsIndex, newItems, removedItemsIndex, removedItems, 
+                            result = self._scrollController.handleMoveItems(newItemsIndex, newItems, removedItemsIndex, removedItems,
                                 newItemsIndex <= collectionStartIndex && self._scrollTop !== 0 ? 'up' : 'down');
                             break;
-                        case IObservable.ACTION_REMOVE: 
+                        case IObservable.ACTION_REMOVE:
                             result = self._scrollController.handleRemoveItems(removedItemsIndex, removedItems);
                             break;
-                        case IObservable.ACTION_RESET: 
+                        case IObservable.ACTION_RESET:
                             result = self._scrollController.handleResetItems();
                             break;
                     }
@@ -2363,13 +2363,13 @@ const _private = {
             self._scrollPagingCtr.shiftToEdge('down', hasMoreData);
         }
         if (self._jumpToEndOnDrawItems) {
-            
-            // Если для подскролла в конец делали reload, то индексы виртуального скролла 
+
+            // Если для подскролла в конец делали reload, то индексы виртуального скролла
             // поставили такие, что последниц элемент уже отображается, scrollToItem не нужен.
             self._notify('doScroll', [self._scrollController?.calculateVirtualScrollHeight() || 'down'], { bubbling: true });
             _private.updateScrollPagingButtons(self, self._getScrollParams());
         } else {
-           
+
             // Последняя страница уже загружена но конец списка не обязательно отображается,
             // если включен виртуальный скролл. ScrollContainer учитывает это в scrollToItem
             _private.scrollToItem(self, lastItemKey, true, true).then(() => {
@@ -2380,7 +2380,7 @@ const _private = {
                 self._notify('doScroll', [self._scrollController?.calculateVirtualScrollHeight() || 'down'], { bubbling: true });
 
                 _private.updateScrollPagingButtons(self, self._getScrollParams());
-            }); 
+            });
         }
     },
 
@@ -3770,6 +3770,9 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
             // https://online.sbis.ru/opendoc.html?guid=caa331de-c7df-4a58-b035-e4310a1896df
             this._updateScrollController(newOptions);
         } else {
+            if (!newOptions.useNewModel) {
+                this._listViewModel.setBackgroundStyle(newOptions.backgroundStyle);
+            }
             this._updateScrollController(newOptions);
         }
 

--- a/Controls/_list/ListViewModel.ts
+++ b/Controls/_list/ListViewModel.ts
@@ -803,6 +803,7 @@ const ListViewModel = ItemsViewModel.extend([entityLib.VersionableMixin], {
      */
     setBackgroundStyle(backgroundStyle) {
         this._options.backgroundStyle = backgroundStyle;
+        this._nextVersion();
     }
 });
 

--- a/Controls/_list/ListViewModel.ts
+++ b/Controls/_list/ListViewModel.ts
@@ -793,6 +793,14 @@ const ListViewModel = ItemsViewModel.extend([entityLib.VersionableMixin], {
         this._options.rowSeparatorSize = _private.getSeparatorSizes({rowSeparatorSize});
         this._display.setRowSeparatorSize(rowSeparatorSize);
         this._nextModelVersion();
+    },
+
+    /**
+     * Обновляет стиль фона фиксированных элемекнтов
+     * @param backgroundStyle
+     */
+    setBackgroundStyle(backgroundStyle) {
+        this._options.backgroundStyle = backgroundStyle;
     }
 });
 


### PR DESCRIPTION
https://online.sbis.ru/doc/d4986f92-388a-4ae5-a88b-12f5db869320  Не рисуется корректный backgroundStyle после смены вида отображения.
В конфигурации SabyGet при смене вида отображения с Плитки на Список, а потом на Таблицу, на ней рисуется серый фон. Проиходит из-за того, что в GridViewModel.ts не приходит акутальное значение backgroundStyle.
Сейчас на таблице рисуется корректный фон из-за костыля в стилях. Можно посмотреть, какие стили рисуются на ячейках по классу .controls-background-gray_theme-default__pink
Как повторить :
https://test.sabyget.ru/shop/restoranov?tab=service
en.vasileva2/en.vasileva123
Нажать в правом верхнем углу на шестеренку - Настройка каталога
В появившемся окне нажать Изменить
Переключить вкладки на Список, а затем на Таблица
ФР: серый фон на таблице (сейчас белый из-за каскада с нашей стороны)
ОР: белый фон на самих ячейках таблицы
За подробностями - к автору ошибки.