### PR TITLE
Документ №1180320031 от 2020-10-13 Горбунова М.В.

### DIFF
--- a/Controls/_tree/Tree/TreeViewModel.ts
+++ b/Controls/_tree/Tree/TreeViewModel.ts
@@ -822,6 +822,9 @@ var
         getChildren: function(rootId, items) {
             return this._hierarchyRelation.getChildren(rootId, items || this._items);
         },
+        thereIsChildItem(): boolean {
+            return this._thereIsChildItem;
+        },
         getDisplayChildrenCount(nodeId: number | string | null, items: RecordSet): number {
             const display = this.getDisplay();
             const curNodeChildren: TreeChildren<Model> = display.getChildren(display.getItemBySourceKey(nodeId));

--- a/Controls/_treeGrid/TreeGridView/TreeGridViewModel.ts
+++ b/Controls/_treeGrid/TreeGridView/TreeGridViewModel.ts
@@ -34,6 +34,7 @@ var _private = {
 var
     TreeGridViewModel = GridViewModel.extend({
         _onNodeRemovedFn: null,
+        _haveItemWithChildren: null,
         constructor: function () {
             TreeGridViewModel.superclass.constructor.apply(this, arguments);
             this._onNodeRemovedFn = this._onNodeRemoved.bind(this);
@@ -361,13 +362,18 @@ var
         _setFooter(footerColumns) {
             TreeGridViewModel.superclass._setFooter.apply(this, arguments);
 
-            if (this._options.expanderIcon !== 'none' && this._options.expanderSize) {
+            let shouldDrawExpanderPadding: boolean = 
+                (this._options.expanderIcon !== 'none' && this._options.expanderPosition === 'default') &&
+                (this._options.expanderVisibility === 'hasChildren' ? this._model.thereIsChildItem() : !this._options.expanderSize);
+
+            if (shouldDrawExpanderPadding) {
                 const expanderColumnIndex = +(this._options.multiSelectVisibility !== 'hidden' && this._options.multiSelectPosition === 'default');
                 const superGetter = this._footer[expanderColumnIndex].getContentClasses;
 
                 this._footer[expanderColumnIndex].getContentClasses = () => {
+                    const expanderSize = this._options.expanderSize || 'default';
                     return superGetter.apply(this, arguments) +
-                        ` controls-TreeGridView__footer__expanderPadding-${this._options.expanderSize.toLowerCase()}_theme-${this._options.theme}`
+                        ` controls-TreeGridView__footer__expanderPadding-${expanderSize.toLowerCase()}_theme-${this._options.theme}`
                 }
             }
         }


### PR DESCRIPTION
https://online.sbis.ru/doc/5968f23a-6319-406f-a7fe-c1278987d63c  Кнопка Ещё уезжает в блоке Папок и Тем отношений, если у папок или Тем отношений нет узлов 
Как повторить:  
1. Бизнес -> Продажи CRM -> Клиенты
ФР:  Кнопка Ещё уезжает в блоке Папок и Тем отношений
ОР:  Кнопка Ещё выровнена по одной линии
Страница: Клиенты/СБИС
Логин: развязка Пароль:   развязка123
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36
Версия:
online-inside_20.6119 (ver 20.6119) - 45 (13.10.2020 - 07:45:00)
Platforma 20.6100 - 140 (12.10.2020 - 17:37:14)
WS 20.6100 - 96 (02.10.2020 - 11:44:17)
Types 20.6100 - 72 (23.09.2020 - 14:41:13)
CONTROLS 20.6100 - 160 (12.10.2020 - 20:56:02)
SDK 20.6100 - 531 (12.10.2020 - 22:16:33)
DISTRIBUTION: ext
GenerateDate: 13.10.2020 - 07:45:00
autoerror_sbislogs 13.10.2020