### PR TITLE
Документ №1176215251 от 2018-11-15 Кузьмин Н.М.

### DIFF
--- a/Controls-demo/Explorer_new/DataHelpers/DataCatalog.ts
+++ b/Controls-demo/Explorer_new/DataHelpers/DataCatalog.ts
@@ -16,6 +16,8 @@ export interface IData {
    isDocument?: Boolean;
    code?: string;
    image?: string;
+   // Специальное свойство для того, чтобы вывести в поиске хлебные крошки в несколько строк
+   SearchResult?: boolean;
 }
 
 export const DataWithLongFolderName = {
@@ -419,10 +421,10 @@ export const Gadgets = {
             id: 3111, parent: 311, 'parent@': true, code: null, price: null, title: 'Жесткие диски SATA'
          },
          {
-            id: 4, parent: null, 'parent@': true, code: null, price: null, title: 'Цифровое фото и видео'
+            id: 4, parent: null, 'parent@': true, code: null, price: null, title: 'Цифровое фото и видео', SearchResult: true
          },
          {
-            id: 41, parent: 4, 'parent@': true, code: null, price: null, title: 'Фотоаппараты'
+            id: 41, parent: 4, 'parent@': true, code: null, price: null, title: 'Фотоаппараты', SearchResult: true
          },
          {
             id: 411, parent: 41, 'parent@': true, code: null, price: null, title: 'Canon'

--- a/Controls-demo/Explorer_new/Search/Index.ts
+++ b/Controls-demo/Explorer_new/Search/Index.ts
@@ -18,6 +18,7 @@ export default class extends Control {
     private _multiselect: 'visible' | 'hidden' = 'hidden';
     // tslint:disable-next-line
     protected _filter: object = {demo: 123};
+    protected _dedicatedItemProperty: string;
 
     protected _itemActions: IItemAction[] = [
         {
@@ -52,6 +53,10 @@ export default class extends Control {
 
     protected _onToggle(): void {
         this._multiselect = this._multiselect === 'visible' ? 'hidden' : 'visible';
+    }
+
+    protected _onToggleDedicatedItemProperty(): void {
+        this._dedicatedItemProperty = !this._dedicatedItemProperty ? 'SearchResult' : undefined;
     }
 
     protected _updateStartingWith(): void {

--- a/Controls-demo/Explorer_new/Search/Search.wml
+++ b/Controls-demo/Explorer_new/Search/Search.wml
@@ -2,7 +2,9 @@
     <div class="controlsDemo__cell">
         <Controls.buttons:Button caption="Toggle multiselectVisibility" on:click="_onToggle()"/>
         <Controls.buttons:Button caption="{{'Установить startingWith в '+ _startingWithBtnCaption}}"
-                                 on:click="_updateStartingWith()" attr:style="padding: 0 5px"/>
+                                 on:click="_updateStartingWith()" attr:style="padding-left: 5px"/>
+        <Controls.buttons:Button caption="{{ !!_dedicatedItemProperty ? 'Выключить' : 'Включить' }} dedicatedItemProperty"
+                                 on:click="_onToggleDedicatedItemProperty()" attr:style="padding-left: 5px"/>
     </div>
     <Controls.list:DataContainer source="{{_viewSource}}" keyProperty="id" bind:filter="_filter">
         <Controls.search:Controller searchParam="title" minSearchLength="{{3}}" searchStartingWith="{{_startingWith}}">
@@ -22,6 +24,7 @@
                             parentProperty="parent"
                             nodeProperty="parent@"
                             multiSelectVisibility="{{_multiselect}}"
+                            dedicatedItemProperty="{{_dedicatedItemProperty}}"
                             columns="{{_columns}}">
                     </Controls.explorer:View>
                 </Controls.list:Container>

--- a/Controls/_display/Search.ts
+++ b/Controls/_display/Search.ts
@@ -38,5 +38,6 @@ export default class Search<S, T extends TreeItem<S> = TreeItem<S>> extends Tree
 
 Object.assign(Search.prototype, {
     _moduleName: 'Controls/display:Search',
-    '[Controls/_display/Search]': true
+    '[Controls/_display/Search]': true,
+    _$dedicatedItemProperty: undefined
 });

--- a/Controls/_explorer/interface/IExplorer.ts
+++ b/Controls/_explorer/interface/IExplorer.ts
@@ -86,3 +86,8 @@ export type TExplorerViewMode = 'table' | 'search' | 'tile' | 'list';
  * @default
  * false
  */
+
+/**
+ * @name Controls/_explorer/interface/IExplorer#dedicatedItemProperty
+ * @cfg {String} Имя свойства узла дерева, которое определяет, что при поиске этот узел должен быть показан отдельной хлебной крошкой.
+ */

--- a/Controls/_list/resources/utils/TreeItemsUtil.ts
+++ b/Controls/_list/resources/utils/TreeItemsUtil.ts
@@ -41,6 +41,7 @@ var
                  nodeProperty: cfg.nodeProperty,
                  collapsedGroups: cfg.collapsedGroups,
                  groupProperty: cfg.groupProperty,
+                 dedicatedItemProperty: cfg.dedicatedItemProperty,
                  theme: cfg.theme,
                  loadedProperty: '!' + cfg.parentProperty + '$',
                  // todo to support merge strategy replace this code on "unique: cfg.loadItemsStrategy === 'merge'".


### PR DESCRIPTION
https://online.sbis.ru/doc/6b1a02d8-6e2b-4051-9cfd-0b922e97d3ee  Прошу доработать отображение записей при поиске в иерархическом представление.
Если в одной ветке находятся две папки, удовлетворяющие условию поиска, то их надо выводить в две разные строки.
В диалоге https://online.sbis.ru/open_dialog.html?guid=01711616-610c-ba1d-9196-861a8151ef18 обсуждали
и договорились о неком логическом поле.