### PR TITLE
Документ №1180258377 от 2020-10-02 Авраменко А.С.

### DIFF
--- a/Controls/_display/interface.ts
+++ b/Controls/_display/interface.ts
@@ -10,12 +10,13 @@ export interface IBaseCollection<S, T extends ICollectionItem> {
     getItemBySourceKey(key: TItemKey): T;
     find(predicate: (item: T) => boolean): T;
     nextVersion(): void;
-    setEventRaising(enabled: boolean, analyze?: boolean): void;
     getCollection(): ISourceCollection<S>;
     getFirst(): T;
     getNextByKey(key: TItemKey): T;
     getPrevByKey(key: TItemKey): T;
     createItem(constructorOptions): T;
+    setEventRaising?(enabled: boolean, analyze?: boolean): void;
+    isEventRaising?(): boolean;
     getCount?(): number;
     getNext?(item: T): T;
     getPrevious?(item: T): T;

--- a/Controls/_itemActions/interface/IItemActionsCollection.ts
+++ b/Controls/_itemActions/interface/IItemActionsCollection.ts
@@ -1,7 +1,6 @@
 import {Model} from 'Types/entity';
-import {EventRaisingMixin} from 'Types/collection';
 
-import {IBaseCollection, ISwipeConfig, ANIMATION_STATE} from 'Controls/display';
+import {IBaseCollection, ISwipeConfig} from 'Controls/display';
 import {IItemActionsItem} from './IItemActionsItem';
 import {IItemActionsTemplateConfig} from './IItemActionsTemplateConfig';
 
@@ -18,7 +17,7 @@ import {IItemActionsTemplateConfig} from './IItemActionsTemplateConfig';
  * @public
  * @author Аверкиев П.А.
  */
-export interface IItemActionsCollection extends IBaseCollection<Model, IItemActionsItem>, Partial<EventRaisingMixin> {
+export interface IItemActionsCollection extends IBaseCollection<Model, IItemActionsItem> {
     // '[Controls/_itemActions/interface/IItemActionsCollection]': true;
 
     /**


### PR DESCRIPTION
https://online.sbis.ru/doc/30fbc41f-c36a-4ab8-8770-f0d011f4e05d canban.model не должна реализовывать setEventRaising/getEventRaising, вместо этого достаточно добавить проверку в itemActionController'e