### PR TITLE
Документ №1180659788 от 2020-11-28 Горбунова М.В.

### DIFF
--- a/Controls/_grid/GridView.ts
+++ b/Controls/_grid/GridView.ts
@@ -304,6 +304,7 @@ var
         isFooterChanged(oldOptions, newOptions): boolean {
             if (
                 // Подвал появился/скрылся
+                (oldOptions.shouldDrawFooter !== newOptions.shouldDrawFooter) ||
                 (!oldOptions.footer && newOptions.footer) ||
                 (oldOptions.footer && !newOptions.footer) ||
                 (!oldOptions.footerTemplate && newOptions.footerTemplate) ||

--- a/Controls/_list/BaseControl/BaseControl.wml
+++ b/Controls/_list/BaseControl/BaseControl.wml
@@ -101,6 +101,7 @@
                 needShowEmptyTemplate="{{ __needShowEmptyTemplate(_options.emptyTemplate, _listViewModel) }}"
                 listModel="{{_listViewModel}}"
                 startDragNDropCallback="{{ _options.itemsDragNDrop ? _startDragNDropCallback }}"
+                shouldDrawFooter="{{ _shouldDrawFooter }}"
                 preventServerSideColumnScroll="{{ _isMounted || _options.preventServerSideColumnScroll }}"
                 on:closeSwipe="_onCloseSwipe()"
                 on:validateCreated="_onValidateCreated()"


### PR DESCRIPTION
https://online.sbis.ru/doc/b19e06ec-ec80-4794-b3bd-7b2c4db351e2 Кнопка Ещё в блоке Тем не выровнена по базовой линии, если пользователь вернулся в корень из двойного провала в реестре Клиенты
Как повторить:

Бизнес -> Продажи CRM -> Клиенты
Провалиться в Моего отдела -> Провалиться в корень в левой колонке
Вернуться в корень реестра по хлебным крошкам из левой колонки
ФР:  Кнопка Ещё у Тем не выровнена по линии с названием Тем
ОР:  Кнопка Ещё у Тем выровнена по линии с названием Тем
Страница: Клиенты
Логин: kula Пароль:   Демо123
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
Версия:
online-inside_20.7200 (ver 20.7200) - 206 (28.11.2020 - 00:51:27)
Platforma 20.7200 - 100 (27.11.2020 - 19:01:50)
WS 20.7200 - 265 (27.11.2020 - 19:01:47)
Types 20.7200 - 263 (27.11.2020 - 16:06:48)
CONTROLS 20.7200 - 264 (27.11.2020 - 17:20:39)
SDK 20.7200 - 324 (27.11.2020 - 20:12:03)
DISTRIBUTION: inside
GenerateDate: 28.11.2020 - 00:51:27
autoerror_sbislogs 28.11.2020