### PR TITLE
Документ №1180753869 от 2020-12-10 Зубарева Г.В.

### DIFF
--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -4915,6 +4915,11 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
             this._unprocessedDragEnteredItem = itemData;
             this._processItemMouseEnterWithDragNDrop(itemData);
         }
+
+        // В chrome/safari mouseEnter происходит всегда, сразу после touch
+        if (!detection.isMobilePlatform) {
+            _private.updateItemActionsOnce(this, this._options);
+        }
         this._notify('itemMouseEnter', [itemData.item, nativeEvent]);
     },
 
@@ -4954,11 +4959,6 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
     },
 
     _mouseEnter(event): void {
-        // В chrome/safari mouseEnter происходит всегда, сразу после touch
-        if (!detection.isMobilePlatform) {
-            _private.updateItemActionsOnce(this, this._options);
-        }
-
         if (this._documentDragging) {
             this._insideDragging = true;
 


### PR DESCRIPTION
https://online.sbis.ru/doc/fd396cae-f06f-4b03-abd7-03e1634da7c7  Настройка календаря. После открытия конфигурации не сразу отображаются кнопки удалить/добавить у пользовательских события/календаря
Как повторить:  
Учет/Бухгалтерия - фильтр по организации
конфигурация, сбросить фильтр
Раскрыть папку, создать событие в папке, закрыть конфигураци/
открыть конфигурацию
навести на любое событие
ФР:  
нет кнопок удалить/добавить у событий
ОР:  
кнопки сразу отображаются
Страница: Бухгалтерия
Логин: карл1 Пароль:   Карл123!
UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.27 Safari/537.36
Версия:
online-inside_20.7213 (ver 20.7213) - 71 (09.12.2020 - 23:08:00)
Platforma 20.7200 - 128 (09.12.2020 - 15:14:03)
WS 20.7200 - 304 (08.12.2020 - 15:15:37)
Types 20.7200 - 304 (08.12.2020 - 15:15:37)
CONTROLS 20.7200 - 309 (09.12.2020 - 21:08:21)
SDK 20.7200 - 394 (09.12.2020 - 21:47:01)
DISTRIBUTION: ext
GenerateDate: 09.12.2020 - 23:08:00
autoerror_sbislogs 10.12.2020