### PR TITLE
Документ №1180808301 от 2020-12-17 Буданков А.А.

### DIFF
--- a/Controls-demo/grid/Grouped/Custom/Custom.wml
+++ b/Controls-demo/grid/Grouped/Custom/Custom.wml
@@ -7,9 +7,6 @@
                     source="{{_viewSource}}"
                     rowSeparatorSize="s"
                     columns="{{_columns}}"
-                    itemActions="{{_itemActions}}"
-                    showEditArrow="{{true}}"
-                    editArrowVisibilityCallback="{{_editArrowVisibilityCallback}}"
                     groupProperty="fullName">
                 <ws:groupTemplate>
                     <ws:partial template="Controls/grid:GroupTemplate" itemData="{{itemData}}" expanderAlign="right">

--- a/Controls-demo/grid/Grouped/Custom/Custom.wml
+++ b/Controls-demo/grid/Grouped/Custom/Custom.wml
@@ -7,6 +7,9 @@
                     source="{{_viewSource}}"
                     rowSeparatorSize="s"
                     columns="{{_columns}}"
+                    itemActions="{{_itemActions}}"
+                    showEditArrow="{{true}}"
+                    editArrowVisibilityCallback="{{_editArrowVisibilityCallback}}"
                     groupProperty="fullName">
                 <ws:groupTemplate>
                     <ws:partial template="Controls/grid:GroupTemplate" itemData="{{itemData}}" expanderAlign="right">

--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -692,6 +692,9 @@ var
         },
         resolveEditArrowVisibility(item, options) {
             let contents = item.getContents();
+            if (item['[Controls/_display/GroupItem]'] || item['[Controls/_display/SearchSeparator]']) {
+                return;
+            }
             if (!options.editArrowVisibilityCallback) {
                 return options.showEditArrow;
             }

--- a/Controls/_grid/interface/IGridControl.ts
+++ b/Controls/_grid/interface/IGridControl.ts
@@ -550,10 +550,10 @@ export interface IGridControl extends IList {
 
 /**
  * @name Controls/_grid/interface/IGridControl#editArrowVisibilityCallback
- * @cfg {TEditArrowVisibilityCallback} Функция обратного вызова для определения видимости кнопки открытия карточки в панели действий по свайпу для конкретной записи.
+ * @cfg {TEditArrowVisibilityCallback} Функция обратного вызова для определения видимости кнопки редактирования
  * @param {Controls/_itemActions/interface/IItemAction/TEditArrowVisibilityCallback.typedef} TEditArrowVisibilityCallback
  * @remark
- * Первый и единственный аргумент - текущая запись, на которой открывается свайп.
+ * Первый и единственный аргумент - текущая запись
  */
 
 /**

--- a/Controls/_itemActions/interface/IItemAction.ts
+++ b/Controls/_itemActions/interface/IItemAction.ts
@@ -245,7 +245,7 @@ export type TItemActionVisibilityCallback = (action: IItemAction, item: Model) =
 /**
  * @typedef {Function} TEditArrowVisibilityCallback
  * @description
- * Функция обратного вызова для определения видимости кнопки редактирования в свайпе.
+ * Функция обратного вызова для определения видимости кнопки редактирования.
  * @param item Model
  */
 export type TEditArrowVisibilityCallback = (item: Model) => boolean;

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -2567,17 +2567,19 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
       describe('getitemDataByItem should resolve showEditArrow', () => {
          let gridViewModel;
          let contentsKey;
+         let editArrowCfg;
 
          beforeEach(() => {
             contentsKey = null;
-            gridViewModel = new gridMod.GridViewModel({
+            editArrowCfg = {
                ...cfg,
                showEditArrow: true,
                editArrowVisibilityCallback: function(contents) {
                   contentsKey = contents.getKey();
                   return false;
                }
-            });
+            };
+            gridViewModel = new gridMod.GridViewModel(editArrowCfg);
          });
 
          it('should resolve showEditArrow', () => {
@@ -2604,6 +2606,28 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             const data = gridViewModel.getItemDataByItem(dispItem);
             assert.equal(contentsKey, '123');
             assert.isFalse(data.showEditArrow);
+         });
+
+         it('should not call visibilityCallback for GroupItem', () => {
+            const item = {
+               '[Controls/_display/GroupItem]': true,
+               getContents: () => null
+            };
+            const spyEditArrowVisibilityCallback = sinon.spy(editArrowCfg, 'editArrowVisibilityCallback');
+            gridMod.GridViewModel._private.resolveEditArrowVisibility(item, editArrowCfg);
+            sinon.assert.notCalled(spyEditArrowVisibilityCallback);
+            spyEditArrowVisibilityCallback.restore();
+         });
+
+         it('should not call visibilityCallback for SearchSeparator', () => {
+            const item = {
+               '[Controls/_display/SearchSeparator]': true,
+               getContents: () => null
+            };
+            const spyEditArrowVisibilityCallback = sinon.spy(editArrowCfg, 'editArrowVisibilityCallback');
+            gridMod.GridViewModel._private.resolveEditArrowVisibility(item, editArrowCfg);
+            sinon.assert.notCalled(spyEditArrowVisibilityCallback);
+            spyEditArrowVisibilityCallback.restore();
          });
       });
 


### PR DESCRIPTION
https://online.sbis.ru/doc/ad8b40c2-00be-4204-8a43-e746e5b1f348  JavaScript API(https://wi.sbis.ru/docs/js/Controls/treeGrid/View/options/editArrowVisibilityCallback/?v=21.1000)
Первый и единственный аргумент - текущая запись, на которой открывается свайп.
Для групп этот callback тоже вызывается и в него приходит просто название группы. Это в целом неожиданное поведение, возможно даже ошибочное.