### PR TITLE
Документ №1180492376 от 2020-11-06 Тихомиров А.А.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -237,7 +237,7 @@ export class Controller {
     /**
      * Деактивирует Swipe для меню операций с записью
      */
-    deactivateSwipe(): void {
+    deactivateSwipe(resetActiveItem: boolean = true): void {
         const currentSwipedItem = this.getSwipeItem();
         if (currentSwipedItem) {
             currentSwipedItem.setSwipeAnimation(null);
@@ -245,7 +245,9 @@ export class Controller {
                 this._restoreItemActions(currentSwipedItem);
             }
             this._setSwipeItem(null);
-            this._collection.setActiveItem(null);
+            if (resetActiveItem) {
+                this._collection.setActiveItem(null);
+            }
             this._collection.setSwipeConfig(null);
             this._collection.nextVersion();
         }

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -5302,6 +5302,7 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
             }
         } else if (eventName === 'menuOpened') {
             _private.removeShowActionsClass(this);
+            _private.getItemActionsController(this, this._options).deactivateSwipe(false);
         }
     },
 

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4530,6 +4530,7 @@ define([
       });
 
       describe('ItemActions menu', () => {
+         let cfg;
          let instance;
          let item;
          let outgoingEventsMap;
@@ -4569,7 +4570,7 @@ define([
 
          beforeEach(async() => {
             outgoingEventsMap = {};
-            const cfg = {
+            cfg = {
                items: new collection.RecordSet({
                   rawData: [
                      {
@@ -4781,6 +4782,19 @@ define([
             instance._onItemActionsMenuClose({id: 'popupId_1'});
             sinon.assert.called(spyShowActions);
             spyShowActions.restore();
+         });
+
+         // Скрытие Swipe ItemActions должно происходить после открытия меню (событие menuOpened)
+         it('should hide Swipe ItemActions on menuOpened event', () => {
+            const fakeEvent = initFakeEvent();
+            const itemActionsController = lists.BaseControl._private.getItemActionsController(instance, cfg);
+            const spyDeactivateSwipe = sinon.spy(itemActionsController, 'deactivateSwipe');
+            const spySetActiveItem = sinon.spy(itemActionsController, 'setActiveItem');
+            instance._onItemActionsMenuResult('menuOpened', null, fakeEvent);
+            sinon.assert.called(spyDeactivateSwipe);
+            sinon.assert.notCalled(spySetActiveItem);
+            spyDeactivateSwipe.restore();
+            spySetActiveItem.restore();
          });
 
          // должен открывать меню, соответствующее новому id Popup


### PR DESCRIPTION
https://online.sbis.ru/doc/3c21d2e1-571a-456f-b4dc-72a9ef4fb6d9  Меню опций с превью. iPad+safari, андроид планшет
После закрытия меню с превью долю секунды еще видно открытое меню по свайпу, потом оно закрывается
1. http://usd-comp175.corp.tensor.ru:777/Controls-demo/app/Controls-demo%2FTile%2FDifferentItemTemplates%2FPreviewTemplate%2FIndex
2. свайп по плитке
3. открыть меню с превью
4. закрыть меню с превью
ОР: после закрытия меню с превью меню по свайпу не видно