### PR TITLE
Документ №1180545574 от 2020-11-13 Галкин В.Ю.

### DIFF
--- a/Controls-demo/list_new/RemoveController/Index.ts
+++ b/Controls-demo/list_new/RemoveController/Index.ts
@@ -1,0 +1,124 @@
+import {Control, TemplateFunction} from 'UI/Base';
+import {Model} from 'Types/entity';
+import {CrudEntityKey} from 'Types/source';
+import {IoC} from 'Env/Env';
+import * as cClone from 'Core/core-clone';
+
+import {IItemAction, TItemActionShowType} from 'Controls/itemActions';
+import {ISelectionObject} from 'Controls/interface';
+import {IRemovableList} from 'Controls/list';
+
+import {RemoveDemoSource} from './RemoveDemoSource';
+import * as template from 'wml!Controls-demo/list_new/RemoveController/RemoveController';
+
+const data: Array<{id: number, title: string}> = [
+   {
+      id: 0,
+      title: 'Стандартное удаление записи'
+   },
+   {
+      id: 1,
+      title: 'Стандартное удаление записи'
+   },
+   {
+      id: 2,
+      title: 'Стандартное удаление записи'
+   },
+   {
+      id: 3,
+      title: 'Стандартное удаление записи'
+   },
+   {
+      id: 4,
+      title: 'Стандартное удаление записи'
+   },
+   {
+      id: 5,
+      title: 'Удаление записи с вопросом'
+   },
+   {
+      id: 6,
+      title: 'Удаление записи с ошибкой'
+   },
+   {
+      id: 7,
+      title: 'Долгое удаление записи'
+   }
+];
+
+export default class RemoveControllerDemo extends Control {
+   protected _template: TemplateFunction = template;
+   protected _viewSource: RemoveDemoSource;
+   protected _itemActions: IItemAction[];
+   protected _selectedKeys: number[] = [];
+   protected _excludedKeys: number[] = [];
+   protected _markedKey: CrudEntityKey;
+
+   protected _beforeMount(options?: {}, contexts?: object, receivedState?: void): Promise<void> | void {
+      this._viewSource = new RemoveDemoSource({
+         keyProperty: 'id',
+         data: cClone(data)
+      });
+      const removeItemsOnDeleteKeyDown = this._removeItemsOnDeleteKeyDown.bind(this);
+      const removeItemOnActionClick = this._removeItemOnActionClick.bind(this);
+
+      this._itemActions = [
+         {
+            id: 'delete',
+            handler: removeItemsOnDeleteKeyDown
+         },
+         {
+            id: 'deleteAction',
+            icon: 'icon-Erase icon-error',
+            showType: TItemActionShowType.TOOLBAR,
+            handler: removeItemOnActionClick
+         }
+      ];
+
+      this._markedKey = 1;
+   }
+
+   protected _itemActionsVisibilityCallback(action: IItemAction, item: Model): boolean {
+      return action.id !== 'delete';
+   }
+
+   private _removeItemsOnDeleteKeyDown(item: Model): void {
+      const selection = {
+         selected: this._selectedKeys && this._selectedKeys.length ? this._selectedKeys : [item.getKey()],
+         excluded: this._excludedKeys
+      };
+      const method: (selection: ISelectionObject) => Promise<void> =
+          this._selectedKeys.length || (selection.selected[0] && selection.selected[0] === 5) ?
+             (this._children.list as undefined as IRemovableList).removeItemsWithConfirmation.bind(this._children.list) :
+             (this._children.list as undefined as IRemovableList).removeItems.bind(this._children.list);
+      method(selection)
+          .then(() => {
+            this._children.list.reload();
+             IoC.resolve('ILogger').info('Delete key has pressed');
+          })
+          .catch((error) => {
+            IoC.resolve('ILogger').error(error);
+          });
+   }
+
+   private _removeItemOnActionClick(item: Model): void {
+      const selection: ISelectionObject = {
+         selected: [item.getKey()],
+         excluded: []
+      };
+      const method: (selection: ISelectionObject) => Promise<void> =
+          selection.selected[0] && selection.selected[0] === 5 ?
+              (this._children.list as undefined as IRemovableList).removeItemsWithConfirmation.bind(this._children.list) :
+              (this._children.list as undefined as IRemovableList).removeItems.bind(this._children.list);
+      method(selection)
+          .then(() => {
+             this._children.list.reload();
+             IoC.resolve('ILogger').info('ItemAction has clicked');
+          })
+          .catch((error) => {
+             IoC.resolve('ILogger').error(error);
+          });
+   }
+
+   static _styles: string[] = ['Controls-demo/list_new/RemoveController/RemoveController'];
+}

--- a/Controls-demo/list_new/RemoveController/RemoveController.less
+++ b/Controls-demo/list_new/RemoveController/RemoveController.less
@@ -1,0 +1,10 @@
+.removeDemo__list {
+   margin: 15px;
+   width: 300px;
+}
+
+.removeDemo__list .ws-ListView__item {
+   min-height: 30px;
+   line-height: 30px;
+   padding-left: 10px;
+}

--- a/Controls-demo/list_new/RemoveController/RemoveController.wml
+++ b/Controls-demo/list_new/RemoveController/RemoveController.wml
@@ -1,0 +1,16 @@
+<div class="removeDemo">
+    <Controls.list:DataContainer source="{{_viewSource}}" keyProperty="id">
+        <Controls.operations:Controller bind:selectedKeys="_selectedKeys"
+                                        bind:excludedKeys="_excludedKeys">
+            <Controls.list:Container>
+                <Controls.list:View
+                        class="removeDemo__list test_list_1"
+                        name="list"
+                        itemActionVisibilityCallback="{{_itemActionsVisibilityCallback}}"
+                        itemActions="{{_itemActions}}"
+                        multiSelectVisibility="visible"
+                        bind:markedKey="_markedKey"/>
+            </Controls.list:Container>
+        </Controls.operations:Controller>
+    </Controls.list:DataContainer>
+</div>

--- a/Controls-demo/list_new/RemoveController/RemoveDemoSource.ts
+++ b/Controls-demo/list_new/RemoveController/RemoveDemoSource.ts
@@ -1,0 +1,21 @@
+import {Memory, CrudEntityKey} from 'Types/source';
+
+export class RemoveDemoSource extends Memory {
+   destroy(keys: CrudEntityKey | CrudEntityKey[], meta?: object): Promise<void> {
+      if (keys.indexOf(6) !== -1) {
+         return Promise.reject('Unable to delete entry with key " 6"');
+
+      } else if (keys.indexOf(7) !== -1) {
+         return new Promise((resolve) => {
+
+            //We simulate the long deletion of records.
+            setTimeout(() => {
+               super.destroy.apply(this, arguments);
+               resolve(true);
+            }, 2500);
+         });
+      }
+
+      return super.destroy.apply(this, arguments);
+   }
+}

--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -20,7 +20,7 @@ import {
 } from './interface/IItemAction';
 import {IItemActionsItem} from './interface/IItemActionsItem';
 import {IItemActionsCollection} from './interface/IItemActionsCollection';
-import {IShownItemAction, IItemActionsContainer} from './interface/IItemActionsContainer';
+import {IShownItemAction, IItemActionsObject} from './interface/IItemActionsObject';
 import {verticalMeasurer} from './measurers/VerticalMeasurer';
 import {horizontalMeasurer} from './measurers/HorizontalMeasurer';
 import {Utils} from './Utils';
@@ -165,7 +165,7 @@ export class Controller {
     // Видимость опций записи
     private _itemActionsVisibility: TItemActionsVisibility;
 
-    private _savedItemActions: IItemActionsContainer;
+    private _savedItemActions: IItemActionsObject;
 
     /**
      * Метод инициализации и обновления параметров.
@@ -453,8 +453,8 @@ export class Controller {
         const assignActionsOnItem = (item): void => {
             if (!item['[Controls/_display/GroupItem]'] && !item['[Controls/_display/SearchSeparator]']) {
                 const contents = Controller._getItemContents(item);
-                const actionsContainer = this._fixActionsDisplayOptions(this._getActionsContainer(item));
-                const itemChanged = Controller._setItemActions(item, actionsContainer, this._actionMode);
+                const actionsObject = this._fixActionsDisplayOptions(this._getActionsObject(item));
+                const itemChanged = Controller._setItemActions(item, actionsObject, this._actionMode);
                 hasChanges = hasChanges || itemChanged;
                 if (itemChanged) {
                     changedItemsIds.push(contents.getKey());
@@ -495,9 +495,10 @@ export class Controller {
      * @private
      */
     private _getMenuActions(item: IItemActionsItem, parentAction: IShownItemAction): IItemAction[] {
-        const actions = item.getActions();
-        const allActions = actions && actions.all;
-        if (allActions) {
+        const contents = Controller._getItemContents(item);
+        const actionsObject = item.getActions();
+        const visibleActions = actionsObject && actionsObject.all && this._filterVisibleActions(actionsObject.all, contents);
+        if (visibleActions) {
             // Кроме как intersection all vs showed мы не можем знать, какие опции Measurer скрыл под кнопку "Ещё",
             // Поэтому для свайпнутой записи имеет смысл показывать в меню те опции, которые отсутствуют в showed
             // массиве или у которых showType MENU_TOOLBAR или MENU
@@ -505,11 +506,11 @@ export class Controller {
             // см. https://online.sbis.ru/opendoc.html?guid=91e7bea1-fa6c-483f-a5dc-860b084ab17a
             // см. https://online.sbis.ru/opendoc.html?guid=b5751217-3833-441f-9eb6-53526625bc0c
             if (item.isSwiped() && parentAction.isMenu) {
-                return allActions.filter((action) => (
-                    !this._hasActionInArray(action, actions.showed) || action.showType !== TItemActionShowType.TOOLBAR)
+                return visibleActions.filter((action) => (
+                    !this._hasActionInArray(action, actionsObject.showed) || action.showType !== TItemActionShowType.TOOLBAR)
                 );
             }
-            return allActions.filter((action) => (
+            return visibleActions.filter((action) => (
                 ((!parentAction || parentAction.isMenu) && action.showType !== TItemActionShowType.TOOLBAR) ||
                 (!!parentAction && !parentAction.isMenu && action.parent === parentAction.id)
             ));
@@ -568,34 +569,20 @@ export class Controller {
         });
     }
 
-    /**
-     * Набирает операции с записью для указанного элемента коллекции
-     * @param item IItemActionsItem
-     * @private
-     */
-    private _collectActionsForItem(item: IItemActionsItem): IItemAction[] {
-        const contents = Controller._getItemContents(item);
-        const itemActions: IItemAction[] = this._itemActionsProperty
-            ? contents.get(this._itemActionsProperty)
-            : this._commonItemActions;
-        return itemActions.filter((action) =>
-            this._itemActionVisibilityCallback(action, contents)
-        );
-    }
-
     private _updateSwipeConfig(actionsContainerWidth: number, actionsContainerHeight: number): void {
         const item = this.getSwipeItem();
         if (!item) {
             return;
         }
+        const contents = Controller._getItemContents(item);
         const menuButtonVisibility = this._getSwipeMenuButtonVisibility(this._contextMenuConfig);
         this._actionsWidth = actionsContainerWidth;
         this._actionsHeight = actionsContainerHeight;
-        const actions = item.getActions().all;
+        const actions = this._filterVisibleActions(item.getActions().all, contents);
         const actionsTemplateConfig = this._collection.getActionsTemplateConfig();
         actionsTemplateConfig.actionAlignment = this._actionsAlignment;
 
-        if (this._editArrowAction && this._editArrowVisibilityCallback(item.getContents())) {
+        if (this._editArrowAction && this._editArrowVisibilityCallback(contents)) {
             this._addEditArrow(actions);
         }
 
@@ -675,20 +662,24 @@ export class Controller {
      * @param item
      * @private
      */
-    private _getActionsContainer(item: IItemActionsItem): IItemActionsContainer {
+    private _getActionsObject(item: IItemActionsItem): IItemActionsObject {
         let showed;
-        const actions = this._collectActionsForItem(item);
+        const contents = Controller._getItemContents(item);
+        const all = this._itemActionsProperty
+            ? contents.get(this._itemActionsProperty)
+            : this._commonItemActions;
+        const visibleActions = this._filterVisibleActions(all, contents);
         if (this._isEditing(item)) {
             showed = [];
-        } else if (actions.length > 1) {
-            showed = actions.filter((action) =>
+        } else if (visibleActions.length > 1) {
+            showed = visibleActions.filter((action) =>
                 !action.parent &&
                 (
                     action.showType === TItemActionShowType.TOOLBAR ||
                     action.showType === TItemActionShowType.MENU_TOOLBAR
                 )
             );
-            if (this._isMenuButtonRequired(actions)) {
+            if (this._isMenuButtonRequired(visibleActions)) {
                 showed.push({
                     id: null,
                     icon: 'icon-SettingsNew',
@@ -698,12 +689,15 @@ export class Controller {
                 });
             }
         } else {
-            showed = actions;
+            showed = visibleActions;
         }
-        return {
-            all: actions,
-            showed
-        };
+        return { all, showed };
+    }
+
+    private _filterVisibleActions(itemActions: IItemAction[], contents: Model): IItemAction[] {
+        return itemActions.filter((action) =>
+            this._itemActionVisibilityCallback(action, contents)
+        );
     }
 
     /**
@@ -747,23 +741,23 @@ export class Controller {
 
     /**
      * Обновляет параметры отображения операций с записью
-     * @param actions
+     * @param actionsObject
      * @private
      */
-    private _fixActionsDisplayOptions(actions: IItemActionsContainer): IItemActionsContainer {
-        if (actions.all && actions.all.length) {
-            actions.all = actions.all.map((action) => {
+    private _fixActionsDisplayOptions(actionsObject: IItemActionsObject): IItemActionsObject {
+        if (actionsObject.all && actionsObject.all.length) {
+            actionsObject.all = actionsObject.all.map((action) => {
                 action.style = Utils.getStyle(action.style, 'itemActions/Controller');
                 action.iconStyle = Utils.getStyle(action.iconStyle, 'itemActions/Controller');
                 action.tooltip = Controller._getTooltip(action);
                 return action;
             });
         }
-        if (actions.showed && actions.showed.length) {
+        if (actionsObject.showed && actionsObject.showed.length) {
             const fixShowOptionsBind = this._fixShownActionOptions.bind(this);
-            actions.showed = clone(actions.showed).map(fixShowOptionsBind);
+            actionsObject.showed = clone(actionsObject.showed).map(fixShowOptionsBind);
         }
-        return actions;
+        return actionsObject;
     }
 
     /**
@@ -814,31 +808,31 @@ export class Controller {
     /**
      * Устанавливает операции с записью для конкретного элемента коллекции
      * @param item
-     * @param actions
+     * @param actionsObject
      * @param actionMode
      * @private
      */
     private static _setItemActions(
         item: IItemActionsItem,
-        actions: IItemActionsContainer,
+        actionsObject: IItemActionsObject,
         actionMode: string
     ): boolean {
-        const oldActions = item.getActions();
-        if (!oldActions || (actions && !this._isMatchingActions(oldActions, actions, actionMode, item.isSwiped()))) {
-            item.setActions(actions, true);
+        const oldActionsObject = item.getActions();
+        if (!oldActionsObject || (actionsObject && !this._isMatchingActions(oldActionsObject, actionsObject, actionMode, item.isSwiped()))) {
+            item.setActions(actionsObject, true);
             return true;
         }
         return false;
     }
 
     private static _isMatchingActions(
-        oldContainer: IItemActionsContainer,
-        newContainer: IItemActionsContainer,
+        oldActionsObject: IItemActionsObject,
+        newActionsObject: IItemActionsObject,
         actionMode: string,
         isSwipedItem: boolean
     ): boolean {
-        const isMatchedAll = this._isMatchingActionLists(oldContainer.all, newContainer.all);
-        const isMatchedShowed = this._isMatchingActionLists(oldContainer.showed, newContainer.showed);
+        const isMatchedAll = this._isMatchingActionLists(oldActionsObject.all, newActionsObject.all);
+        const isMatchedShowed = this._isMatchingActionLists(oldActionsObject.showed, newActionsObject.showed);
         return actionMode === 'adaptive' && !isSwipedItem ? isMatchedAll : (isMatchedAll && isMatchedShowed);
     }
 
@@ -866,11 +860,11 @@ export class Controller {
     }
 
     private static _needsHorizontalMeasurement(config: ISwipeConfig): boolean {
-        const actions = config.itemActions;
+        const actionsObject = config.itemActions;
         return (
-            actions &&
-            actions.showed?.length === 1 &&
-            actions.all?.length > 1
+            actionsObject &&
+            actionsObject.showed?.length === 1 &&
+            actionsObject.all?.length > 1
         );
     }
 

--- a/Controls/_itemActions/interface/IItemActionsItem.ts
+++ b/Controls/_itemActions/interface/IItemActionsItem.ts
@@ -1,4 +1,4 @@
-import {IItemActionsContainer} from './IItemActionsContainer';
+import {IItemActionsObject} from './IItemActionsObject';
 import {Model} from 'Types/entity';
 import {ANIMATION_STATE, ICollectionItem} from 'Controls/display';
 
@@ -22,18 +22,18 @@ export interface IItemActionsItem extends ICollectionItem {
      * Получить опции записи
      * @method
      * @public
-     * @return {Controls/_itemActions/interface/IItemActionsContainer} Опции записи
+     * @return {Controls/_itemActions/interface/IItemActionsObject} Опции записи
      */
-    getActions(): IItemActionsContainer;
+    getActions(): IItemActionsObject;
 
     /**
      * Установить опции записи
-     * @param {Controls/_itemActions/interface/IItemActionsContainer} actions Опции записи
+     * @param {Controls/_itemActions/interface/IItemActionsObject} actions Опции записи
      * @param {boolean} [silent=false] Не генерировать событие onCurrentChange
      * @method
      * @public
      */
-    setActions(actions: IItemActionsContainer, silent?: boolean): void;
+    setActions(actions: IItemActionsObject, silent?: boolean): void;
 
     /**
      * Получить состояние активности текущего элемента

--- a/Controls/_itemActions/interface/IItemActionsObject.ts
+++ b/Controls/_itemActions/interface/IItemActionsObject.ts
@@ -30,7 +30,7 @@ export interface IShownItemAction extends IItemAction {
     isMenu?: boolean;
 }
 
-export interface IItemActionsContainer {
+export interface IItemActionsObject {
     all: IItemAction[];
     showed: IShownItemAction[];
 }

--- a/Controls/_itemActions/measurers/HorizontalMeasurer.ts
+++ b/Controls/_itemActions/measurers/HorizontalMeasurer.ts
@@ -8,7 +8,7 @@ import {
    TItemActionsSize,
    TActionCaptionPosition
 } from '../interface/IItemAction';
-import { IShownItemAction } from '../interface/IItemActionsContainer';
+import { IShownItemAction } from '../interface/IItemActionsObject';
 import { MeasurerUtils } from './MeasurerUtils';
 import { ISwipeActionTemplateConfig } from '../interface/ISwipeActionTemplateConfig';
 

--- a/Controls/_itemActions/measurers/ItemActionMeasurer.ts
+++ b/Controls/_itemActions/measurers/ItemActionMeasurer.ts
@@ -1,6 +1,6 @@
 import {TItemActionsSize} from '../interface/IItemAction';
 import {MeasurerUtils} from './MeasurerUtils';
-import {IItemActionsContainer} from '../interface/IItemActionsContainer';
+import {IItemActionsObject} from '../interface/IItemActionsObject';
 
 const ICON_SIZES = {
     m: 24,
@@ -25,11 +25,11 @@ export function getAvailableActionsCount(iconSize: TItemActionsSize, availableSi
 }
 
 export function getActions(
-    actions: IItemActionsContainer,
+    actions: IItemActionsObject,
     iconSize: TItemActionsSize,
     aligment: string,
     containerSize: number
-): IItemActionsContainer {
+): IItemActionsObject {
     let showedActions = [];
     const allActions = MeasurerUtils.getActualActions(actions.all);
     const rootActions = allActions.filter((action) => !action['parent@']);

--- a/Controls/_itemActions/measurers/MeasurerUtils.ts
+++ b/Controls/_itemActions/measurers/MeasurerUtils.ts
@@ -1,5 +1,5 @@
 import { TItemActionShowType } from '../interface/IItemAction';
-import { IShownItemAction } from '../interface/IItemActionsContainer';
+import { IShownItemAction } from '../interface/IItemActionsObject';
 
 /**
  * Утилиты для измерения опций свайпа, которые нужно показать на странице

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -752,6 +752,7 @@ const _private = {
             const deleteAction = itemActions.all.find((itemAction: IItemAction) => itemAction.id === DELETE_ACTION_KEY);
             if (deleteAction) {
                 _private.handleItemActionClick(self, deleteAction, event, toggledItem, false);
+                event.stopImmediatePropagation();
             }
         }
     },
@@ -5491,7 +5492,8 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
                 || key === 33 // PageUp
                 || key === 34 // PageDown
                 || key === 35 // End
-                || key === 36; // Home
+                || key === 36 // Home
+                || key === 46; // Delete
             EventUtils.keysHandler(event, HOT_KEYS, _private, this, dontStop);
         }
     },

--- a/Controls/itemActions.ts
+++ b/Controls/itemActions.ts
@@ -22,7 +22,7 @@ export {
     TIconStyle,
     IItemAction
 } from './_itemActions/interface/IItemAction';
-export {IShownItemAction, IItemActionsContainer} from './_itemActions/interface/IItemActionsContainer';
+export {IShownItemAction, IItemActionsObject} from './_itemActions/interface/IItemActionsObject';
 export {IContextMenuConfig} from './_itemActions/interface/IContextMenuConfig';
 export {IItemActionsItem} from './_itemActions/interface/IItemActionsItem';
 export {IItemActionsCollection} from './_itemActions/interface/IItemActionsCollection';

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -1594,14 +1594,14 @@ define([
             assert.isFalse(isHandlerCalled);
          });
 
-         it('should not work when itemAction "delete" is not visible', async () => {
+         it('should work even when itemAction "delete" is not visible', async () => {
             await initTest({
                itemActions: [{ id: 'delete', handler: () => {isHandlerCalled = true} }, { id: 1 }, { id: 2 }],
                itemActionVisibilityCallback: (action, item) => action.id !== 'delete',
             });
             instance.setMarkedKey(1);
             lists.BaseControl._private.keyDownDel(instance, event);
-            assert.isFalse(isHandlerCalled);
+            assert.isTrue(isHandlerCalled);
          });
 
          it('should not work when no item is marked', () => {

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -1553,7 +1553,8 @@ define([
          beforeEach(() => {
             isHandlerCalled = false;
             event = {
-               preventDefault: () => {}
+               preventDefault: () => {},
+               stopImmediatePropagation: () => {}
             };
          });
 

--- a/tests/ControlsUnit/Selector/Controller.test.js
+++ b/tests/ControlsUnit/Selector/Controller.test.js
@@ -1,0 +1,100 @@
+define("ControlsUnit/Selector/Controller.test", ["require", "exports", "Types/entity", "Types/collection", "chai", "Controls/lookupPopup"], function (require, exports, entity_1, collection_1, chai_1, lookupPopup_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var getSelectedItems = function (itemsCount) {
+        var items = new collection_1.List();
+        itemsCount = isNaN(itemsCount) ? 5 : itemsCount;
+        for (var i = 0; i < itemsCount; i++) {
+            items.add(new entity_1.Model({
+                rawData: {
+                    id: i,
+                    otherId: 'otherId-' + i,
+                    title: 'title-' + i
+                },
+                keyProperty: 'id'
+            }));
+        }
+        return items;
+    };
+    describe('Controls/_lookupPopup/Controller', function () {
+        it('prepareItems', function () {
+            var itemList = new collection_1.List({ items: [1, 2] });
+            chai_1.assert.equal(lookupPopup_1.Controller._prepareItems()._moduleName, 'Types/collection:List');
+        });
+        it('addItemToSelected', function () {
+            var itemNew = new entity_1.Model({
+                rawData: {
+                    id: 'test',
+                    title: 'test'
+                }
+            });
+            var itemToReplace = new entity_1.Model({
+                rawData: {
+                    id: 0,
+                    title: 'test'
+                }
+            });
+            var selectedItems = getSelectedItems();
+            lookupPopup_1.Controller._addItemToSelected(itemNew, selectedItems, 'id');
+            chai_1.assert.equal(selectedItems.getCount(), 6);
+            chai_1.assert.equal(selectedItems.at(5).get('title'), 'test');
+            lookupPopup_1.Controller._addItemToSelected(itemToReplace, selectedItems, 'id');
+            chai_1.assert.equal(selectedItems.getCount(), 6);
+            chai_1.assert.equal(selectedItems.at(0).get('title'), 'test');
+        });
+        it('removeFromSelected', function () {
+            var selectedItems = getSelectedItems();
+            var itemToRemove = new entity_1.Model({
+                rawData: {
+                    id: 0,
+                    title: 'test'
+                }
+            });
+            lookupPopup_1.Controller._removeFromSelected(itemToRemove, selectedItems, 'id');
+            chai_1.assert.equal(selectedItems.getCount(), 4);
+            chai_1.assert.equal(selectedItems.at(0).get('id'), 1);
+        });
+        describe('processSelectionResult', function () {
+            it('multiSelect is not "false"', function () {
+                var selectedItems = getSelectedItems();
+                var newSelected = getSelectedItems();
+                var result = {
+                    initialSelection: getSelectedItems().clone(),
+                    resultSelection: newSelected,
+                    keyProperty: 'id'
+                };
+                newSelected.removeAt(0);
+                newSelected.removeAt(0);
+                newSelected.removeAt(2);
+                lookupPopup_1.Controller._processSelectionResult([result], selectedItems);
+                chai_1.assert.equal(selectedItems.getCount(), 2);
+                chai_1.assert.equal(selectedItems.at(0).get('id'), 2);
+                chai_1.assert.equal(selectedItems.at(1).get('id'), 3);
+                selectedItems.clear();
+                lookupPopup_1.Controller._processSelectionResult([result], selectedItems, true, 'otherId');
+                chai_1.assert.equal(selectedItems.getCount(), 2);
+                chai_1.assert.equal(selectedItems.at(0).get('otherId'), 'otherId-2');
+                chai_1.assert.equal(selectedItems.at(1).get('otherId'), 'otherId-3');
+            });
+            describe('multiSelect is "false"', function () {
+                var selectedItems = getSelectedItems(0);
+                var newSelectedItems = getSelectedItems(1);
+                var result = {
+                    initialSelection: [],
+                    resultSelection: newSelectedItems,
+                    keyProperty: 'id',
+                    selectCompleteInitiator: false
+                };
+                it('selectCompleteInitiator is "false"', function () {
+                    lookupPopup_1.Controller._processSelectionResult([result], selectedItems, false);
+                    chai_1.assert.equal(selectedItems.getCount(), 0);
+                });
+                it('selectCompleteInitiator is "true"', function () {
+                    result.selectCompleteInitiator = true;
+                    lookupPopup_1.Controller._processSelectionResult([result], selectedItems, false);
+                    chai_1.assert.equal(selectedItems.getCount(), 1);
+                });
+            });
+        });
+    });
+});

--- a/tests/ControlsUnit/itemActions/ItemActionsMeasurer.ts
+++ b/tests/ControlsUnit/itemActions/ItemActionsMeasurer.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {IItemAction, IItemActionsContainer} from 'Controls/ItemActions';
+import {IItemAction, IItemActionsObject} from 'Controls/ItemActions';
 import {getActions} from 'Controls/_itemActions/measurers/ItemActionMeasurer';
 
 describe('itemActionsMeasurer', () => {


### PR DESCRIPTION
https://online.sbis.ru/doc/9c358999-2618-42a5-a599-34ee168dafe2  Для решения надошибки нужно проработать возможность удаления по Delete с разными id в itemActions, т.к. задать уникальный не можем в связи с двумя операциями с разным showType, подробности в ленте надошибки.
Ссылка на вопрос:
https://online.sbis.ru/forum/2bcadf16-d557-4ea7-b1cb-f50dc9193acd
Ссылка на задачу с ответом:
https://online.sbis.ru/doc/fadf31c1-5092-42bd-8686-31e3947e4d63
ФР: Платформенное удаление при разных id itemActions не работает
ОР: Работает платформенное удаление при разных id itemActions