### PR TITLE
Документ №1180415126 от 2020-10-27 Антонов Д.Н.

### DIFF
--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -696,6 +696,9 @@ const _private = {
     },
 
     enterHandler(self, event) {
+        if (event.nativeEvent.ctrlKey) {
+            return;
+        }
         if (_private.hasMarkerController(self)) {
             const markerController = _private.getMarkerController(self);
             const markedKey = markerController.getMarkedKey();
@@ -707,6 +710,7 @@ const _private = {
                 }
             }
         }
+        event.stopImmediatePropagation();
     },
     spaceHandler(self: typeof BaseControl, event: SyntheticEvent):void {
         if (self._options.multiSelectVisibility === 'hidden' || self._options.markerVisibility === 'hidden') {
@@ -5519,7 +5523,8 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
                 || key === 34 // PageDown
                 || key === 35 // End
                 || key === 36 // Home
-                || key === 46; // Delete
+                || key === 46 // Delete
+                || key === constants.key.enter;
             EventUtils.keysHandler(event, HOT_KEYS, _private, this, dontStop);
         }
     },

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -1471,13 +1471,19 @@ define([
             assert.deepEqual(options, { bubbling: true });
          };
 
+         let ctrlKey = false;
+         function getEvent() {
+            return { nativeEvent: { ctrlKey }, isStopped: () => true, stopImmediatePropagation: () => {} }
+         }
+
          // Without marker
-         lists.BaseControl._private.enterHandler(baseControl, { nativeEvent: {} });
+         lists.BaseControl._private.enterHandler(baseControl, getEvent());
          assert.isTrue(notified);
 
          // With CtrlKey
+         ctrlKey = true;
          notified = false;
-         lists.BaseControl._private.enterHandler(baseControl, { nativeEvent: { ctrlKey: true } });
+         lists.BaseControl._private.enterHandler(baseControl, getEvent());
          assert.isFalse(notified);
       });
 
@@ -1487,6 +1493,7 @@ define([
             notified = false;
 
          function enterClick(markedItem) {
+            const event = { nativeEvent: { ctrlKey: false }, isStopped: () => true, stopImmediatePropagation: () => {} };
             lists.BaseControl._private.enterHandler(
             {
                _options: {useNewModel: false},
@@ -1497,7 +1504,7 @@ define([
                   notified = true;
                },
                _loadingIndicatorState: 'all'
-            }, {nativeEvent: {}});
+            }, event);
          }
 
          // Without marker

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -1472,8 +1472,13 @@ define([
          };
 
          // Without marker
-         lists.BaseControl._private.enterHandler(baseControl);
+         lists.BaseControl._private.enterHandler(baseControl, { nativeEvent: {} });
          assert.isTrue(notified);
+
+         // With CtrlKey
+         notified = false;
+         lists.BaseControl._private.enterHandler(baseControl, { nativeEvent: { ctrlKey: true } });
+         assert.isFalse(notified);
       });
 
       it('enterHandler while loading', function() {
@@ -1492,7 +1497,7 @@ define([
                   notified = true;
                },
                _loadingIndicatorState: 'all'
-            });
+            }, {nativeEvent: {}});
          }
 
          // Without marker


### PR DESCRIPTION
https://online.sbis.ru/doc/ae77ae23-69cc-4a71-9bd2-ef36c68faf1e В отчете клиенты и на вкладке клиенты не работает хоткей ctrl+enter в фильтре сотрудники
Как повторить:

Контакты - телефония - сводно
отчеты - клиенты/вкладка клиенты
открыть фильтр звонковые группы - выделить несколько - нажать ctrl+enter(аналогично в воронке фильтров в отчете)
ФР:
Ничего не происходит
ОР:
При нажатии ctrl+enter кнопка "Выбрать" срабатывает