### PR TITLE
Документ №1180825010 от 2020-12-21 Арсланова А.А.

### DIFF
--- a/Controls/_treeGrid/SearchView.ts
+++ b/Controls/_treeGrid/SearchView.ts
@@ -27,7 +27,10 @@ var
             if (!this._itemClickNotifiedByPathClick) {
                 const lastBreadCrumb = item.getContents()[item.getContents().length - 1];
                 if (lastBreadCrumb) {
-                    this._notify('itemClick', [lastBreadCrumb, e, this._getCellIndexByEventTarget(e)], {bubbling: true});
+
+                    // Тут нельзя делать bubbling, т.к. это приводит к отправке в TreeGrid двух событий itemClick
+                    // Одно - из SearchView, второе - из BaseControl
+                    this._notify('itemClick', [lastBreadCrumb, e, this._getCellIndexByEventTarget(e)]);
                 }
             }
             this._itemClickNotifiedByPathClick = false;


### PR DESCRIPTION
https://online.sbis.ru/doc/4a3d6467-4831-41a9-99f0-546a5a5d5b61 Отображаются по две вплывашки/окна ошибки при выборе папки для переноса из результатов поиска в реестре диалогов
Как повторить: 

(house/house-123), вкладка Диалоги
у диалога выбрать опцию Перенести
ввести название папки в строке поиска в панели Выбора раздела
выбрать папку из результатов поиска
ФР:  отображаются две всплывашки "Диалог перенесен в папку"; отображаются два окна ошибки при попытке переноса диалога в ту же папку, в которой она находится
ОР:  одна всплывашка/одно окно ошибки
Страница: Контакты
Логин: Пароль:   
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
Версия:
online-inside_20.7225 (ver 20.7225) - 117 (21.12.2020 - 00:40:42)
Platforma 20.7200 - 150 (20.12.2020 - 19:16:16)
WS 20.7200 - 334 (18.12.2020 - 19:50:12)
Types 20.7200 - 334 (18.12.2020 - 19:50:12)
CONTROLS 20.7200 - 335 (19.12.2020 - 19:51:59)
SDK 20.7200 - 437 (20.12.2020 - 20:28:21)
DISTRIBUTION: inside
GenerateDate: 21.12.2020 - 00:40:42
autoerror_sbislogs 21.12.2020