### PR TITLE
Документ №1180884407 от 2020-12-28 Марков Д.Е.

### DIFF
--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -4320,6 +4320,8 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
         this._unregisterMouseMove();
         this._unregisterMouseUp();
 
+        _private.closePopup(this, this._itemActionsMenuId);
+
         BaseControl.superclass._beforeUnmount.apply(this, arguments);
     },
 


### PR DESCRIPTION
https://online.sbis.ru/doc/94067057-0312-41cc-acd8-61d6ab56bb14  Не закрывается попап выбора стола после подтверждения выбора столов
Как повторить:  
Престо - Зал/Заказы
Выбрать стол через правый клик
Правый клик на любом столе
Нажать на "Ок" в шапке
ФР:  открылось окно формирования заказа, попап не закрылся
ОР:  попап закрылся при переходе на экран заказа
Страница: Presto/СБИС
Логин: марковденис Пароль: марковденис123  
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
Версия:
online-inside_20.7227 (ver 20.7227.2) - 100 (27.12.2020 - 19:19:51)
Platforma 20.7200 - 170 (25.12.2020 - 12:10:37)
WS 20.7200 - 341 (23.12.2020 - 11:30:51)
Types 20.7200 - 341 (23.12.2020 - 11:30:51)
CONTROLS 20.7200 - 344 (23.12.2020 - 18:58:40)
SDK 20.7200 - 458 (25.12.2020 - 13:22:38)
DISTRIBUTION: ext
GenerateDate: 27.12.2020 - 19:19:51
StableSDK
autoerror_sbislogs 28.12.2020