### PR TITLE
Документ №1181186677 от 2021-02-12 Земцова А.В.

### DIFF
--- a/Controls/_gridNew/Render/grid/Item.wml
+++ b/Controls/_gridNew/Render/grid/Item.wml
@@ -66,6 +66,7 @@
                 <Controls.scroll:StickyHeader position="{{ (item || itemData).getStickyHeaderPosition() }}"
                                               mode="{{ (item || itemData).getStickyHeaderMode() }}"
                                               shadowVisibility="{{column.shadowVisibility || 'lastVisible'}}"
+                                              backgroundStyle="{{ backgroundStyle }}"
                                               attr:class="{{ column.getWrapperClasses(theme, backgroundColorStyle, style, highlightOnHover) }}"
                                               attr:style="{{ column.getWrapperStyles() }}">
                     <ws:partial template="COLUMN" gridColumn="{{ column }}"/>

--- a/Controls/_treeGridNew/render/grid/Item.wml
+++ b/Controls/_treeGridNew/render/grid/Item.wml
@@ -86,6 +86,7 @@
             <Controls.scroll:StickyHeader position="topbottom"
                                           mode="stackable"
                                           shadowVisibility="{{column.shadowVisibility || 'lastVisible'}}"
+                                          backgroundStyle="{{ backgroundStyle }}"
                                           attr:class="{{ column.getWrapperClasses(theme, backgroundColorStyle, style, highlightOnHover) }}"
                                           attr:style="{{ column.getWrapperStyles(containerSize) }}">
                <ws:partial template="COLUMN" gridColumn="{{ column }}"/>


### PR DESCRIPTION
https://online.sbis.ru/doc/e1d284ad-a54a-473a-b956-6716a8bad15d  Не соответствует макету всплывашка на документе Счета 
Как повторить:  
Бизнес/Продажи/Счета, открыть Счет
Навести курсор на флажок у позиции 
ФР:  
Всплывашка не соответствует макету, название столбца Цена на белом фоне (см. скрин ФР)
ОР:  
Нет белого фона вверху всплывашки
Страница: Исходящие счета
Логин: Гремлины123 Пароль: Гремлины1234  
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36
Версия:
online-inside_21.1100 (ver 21.1100) - 1533.248 (11.02.2021 - 14:10:06)
Platforma 21.1100 - 128 (11.02.2021 - 10:23:28)
WS 21.1100 - 323 (11.02.2021 - 10:23:05)
Types 21.1100 - 323 (11.02.2021 - 10:23:05)
CONTROLS 21.1100 - 324 (11.02.2021 - 11:42:31)
SDK 21.1100 - 337 (11.02.2021 - 13:18:12)
DISTRIBUTION: ext
GenerateDate: 11.02.2021 - 17:42:25
StableSDK
autoerror_sbislogs 12.02.2021