### PR TITLE
Документ №1181224388 от 2021-02-17 Бородин В.О.

### DIFF
--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -5843,12 +5843,16 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
         const itemContainer = (swipeEvent.target as HTMLElement).closest('.controls-ListView__itemV');
         const swipeContainer = _private.getSwipeContainerSize(itemContainer as HTMLElement);
         let itemActionsController: ItemActionsController;
+        let isSwipeEventHandled: boolean = false;
 
         if (swipeEvent.nativeEvent.direction === 'left') {
             this.setMarkedKey(key);
             _private.updateItemActionsOnce(this, this._options);
             itemActionsController = _private.getItemActionsController(this, this._options);
-            itemActionsController?.activateSwipe(key, swipeContainer?.width, swipeContainer?.height);
+            if (itemActionsController) {
+                itemActionsController.activateSwipe(key, swipeContainer?.width, swipeContainer?.height);
+                isSwipeEventHandled = true;
+            }
         }
         if (swipeEvent.nativeEvent.direction === 'right') {
             // Тут не надо инициализировать контроллер, если он не проинициализирован
@@ -5856,6 +5860,7 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
             if (swipedItem) {
                 this._itemActionsController.startSwipeCloseAnimation();
                 this._listViewModel.nextVersion();
+                isSwipeEventHandled = true;
 
                 // Для сценария, когда свайпнули одну запись и потом свайпнули вправо другую запись
                 if (swipedItem !== item) {
@@ -5867,6 +5872,7 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
                     this._notify('checkboxClick', [key, item.isSelected()]);
                     const newSelection = _private.getSelectionController(this).toggleItem(key);
                     _private.changeSelection(this, newSelection);
+                    isSwipeEventHandled = true;
                     // Animation should be played only if checkboxes are visible.
                     if (_private.hasSelectionController(this)) {
                         _private.getSelectionController(this).startItemAnimation(key);
@@ -5875,8 +5881,8 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
                 this.setMarkedKey(key);
             }
         }
-        if (!this._options.itemActions && item.isSwiped()) {
-            this._notify('itemSwipe', [item, swipeEvent, swipeContainer?.clientHeight]);
+        if (!isSwipeEventHandled) {
+            this._notify('itemSwipe', [item, swipeEvent, swipeContainer?.height]);
         }
     },
 

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -4395,85 +4395,105 @@ define([
                swipeEvent = undefined;
             });
 
-            beforeEach(() => {
-               return initTest({
-                  itemActions: [
-                     {
-                        id: 1,
-                        showType: 2,
-                        'parent@': true
+            describe('with ItemActions', () => {
+               beforeEach(() => {
+                  return initTest({
+                     itemActions: [
+                        {
+                           id: 1,
+                           showType: 2,
+                           'parent@': true
+                        },
+                        {
+                           id: 2,
+                           showType: 0,
+                           parent: 1
+                        },
+                        {
+                           id: 3,
+                           showType: 0,
+                           parent: 1
+                        }
+                     ]
+                  }).then(() => lists.BaseControl._private.updateItemActions(instance, instance._options));
+               });
+
+               // Если Активирован свайп на одной записи и свайпнули по любой другой записи, надо закрыть свайп
+               it('should close swipe when any record has been swiped right', () => {
+                  const item = instance._listViewModel.at(0);
+                  const spySetSwipeAnimation = sinon.spy(item, 'setSwipeAnimation');
+                  item.setSwiped(true, true);
+                  instance._onItemSwipe({}, instance._listViewModel.at(2), swipeEvent);
+
+                  sinon.assert.calledWith(spySetSwipeAnimation, 'close');
+                  spySetSwipeAnimation.restore();
+               });
+
+               // Если Активирован свайп на одной записи и свайпнули по любой другой записи, надо переместить маркер
+               it('should change marker when any other record has been swiped right', () => {
+                  const spySetMarkedKey = sinon.spy(instance, 'setMarkedKey');
+                  instance._listViewModel.at(0).setSwiped(true, true);
+                  instance._onItemSwipe({}, instance._listViewModel.at(2), swipeEvent);
+
+                  sinon.assert.calledOnce(spySetMarkedKey);
+                  spySetMarkedKey.restore();
+               });
+
+               // Если Активирован свайп на одной записи и свайпнули по той же записи, не надо вызывать установку маркера
+               it('should deactivate swipe when any other record has been swiped right', () => {
+                  const spySetMarkedKey = sinon.spy(instance, 'setMarkedKey');
+                  instance._listViewModel.at(0).setSwiped(true, true);
+                  instance._onItemSwipe({}, instance._listViewModel.at(0), swipeEvent);
+
+                  sinon.assert.notCalled(spySetMarkedKey);
+                  spySetMarkedKey.restore();
+               });
+
+               // Должен бросать событие наверх, если оно не обработано
+               it('it should fire event whe it wasn\'t fired', () => {
+                  const spyNotify = sinon.spy(instance, '_notify');
+                  instance._listViewModel.at(0).setSwiped(true, true);
+                  instance._onItemSwipe({}, instance._listViewModel.at(0), swipeEvent);
+                  sinon.assert.notCalled(spyNotify);
+                  spyNotify.restore();
+               });
+
+               // Должен работать свайп по breadcrumbs
+               it('should work with breadcrumbs', () => {
+                  swipeEvent = initSwipeEvent('left');
+                  const itemAt0 = instance._listViewModel.at(0);
+                  const breadcrumbItem = {
+                     '[Controls/_display/BreadcrumbsItem]': true,
+                     _$active: false,
+                     isSelected: () => true,
+                     getContents: () => ['fake', 'fake', 'fake', itemAt0.getContents() ],
+                     setActive: function() {
+                        this._$active = true;
                      },
-                     {
-                        id: 2,
-                        showType: 0,
-                        parent: 1
-                     },
-                     {
-                        id: 3,
-                        showType: 0,
-                        parent: 1
-                     }
-                  ]
-               }).then(() => lists.BaseControl._private.updateItemActions(instance, instance._options));
+                     getActions: () => ({
+                        all: [{
+                           id: 2,
+                           showType: 0
+                        }]
+                     })
+                  };
+                  const stubActivateSwipe = sinon.stub(instance._itemActionsController, 'activateSwipe')
+                     .callsFake((itemKey, actionsContainerWidth, actionsContainerHeight) => {
+                        assert.equal(itemKey, itemAt0.getContents().getKey());
+                        stubActivateSwipe.restore();
+                     });
+
+                  instance._onItemSwipe({}, breadcrumbItem, swipeEvent);
+               });
             });
 
-            // Если Активирован свайп на одной записи и свайпнули по любой другой записи, надо закрыть свайп
-            it('should close swipe when any record has been swiped right', () => {
-               const item = instance._listViewModel.at(0);
-               const spySetSwipeAnimation = sinon.spy(item, 'setSwipeAnimation');
-               item.setSwiped(true, true);
-               instance._onItemSwipe({}, instance._listViewModel.at(2), swipeEvent);
-
-               sinon.assert.calledWith(spySetSwipeAnimation, 'close');
-               spySetSwipeAnimation.restore();
-            });
-
-            // Если Активирован свайп на одной записи и свайпнули по любой другой записи, надо переместить маркер
-            it('should change marker when any other record has been swiped right', () => {
-               const spySetMarkedKey = sinon.spy(instance, 'setMarkedKey');
-               instance._listViewModel.at(0).setSwiped(true, true);
-               instance._onItemSwipe({}, instance._listViewModel.at(2), swipeEvent);
-
-               sinon.assert.calledOnce(spySetMarkedKey);
-               spySetMarkedKey.restore();
-            });
-
-            // Если Активирован свайп на одной записи и свайпнули по той же записи, не надо вызывать установку маркера
-            it('should deactivate swipe when any other record has been swiped right', () => {
-               const spySetMarkedKey = sinon.spy(instance, 'setMarkedKey');
-               instance._listViewModel.at(0).setSwiped(true, true);
+            // Должен бросать событие наверх, если оно не обработано
+            it('it should fire event whe it wasn\'t fired', () => {
+               initTest();
+               const spyNotify = sinon.spy(instance, '_notify');
                instance._onItemSwipe({}, instance._listViewModel.at(0), swipeEvent);
-
-               sinon.assert.notCalled(spySetMarkedKey);
-               spySetMarkedKey.restore();
-            });
-
-            // Должен работать свайп по breadcrumbs
-            it('should work with breadcrumbs', () => {
-               swipeEvent = initSwipeEvent('left');
-               const itemAt0 = instance._listViewModel.at(0);
-               const breadcrumbItem = {
-                  '[Controls/_display/BreadcrumbsItem]': true,
-                  _$active: false,
-                  isSelected: () => true,
-                  getContents: () => ['fake', 'fake', 'fake', itemAt0.getContents() ],
-                  setActive: function() {
-                     this._$active = true;
-                  },
-                  getActions: () => ({
-                     all: [{
-                        id: 2,
-                        showType: 0
-                     }]
-                  })
-               };
-               const stubActivateSwipe = sinon.stub(instance._itemActionsController, 'activateSwipe')
-                  .callsFake((itemKey, actionsContainerWidth, actionsContainerHeight) => {
-                     assert.equal(itemKey, itemAt0.getContents().getKey());
-                     stubActivateSwipe.restore();
-                  });
-
-               instance._onItemSwipe({}, breadcrumbItem, swipeEvent);
+               sinon.assert.called(spyNotify);
+               spyNotify.restore();
             });
          });
 


### PR DESCRIPTION
https://online.sbis.ru/doc/0a61c6ad-fedc-48b2-a5c0-ddce1492709f  Родительскую ошибку невозможно решить без установки кастомного обработчика правого свайпа. При этом событие свайпа не приходит от реестра WNCCore.registry:View (создающего внутри себя Controls.explorer:View), который я использую:
https://git.sbis.ru/root/sbis3-nomcatalog/-/blob/rc-21.2100/client/Suppliers/Price/Price.wml#L223
Т.е. если я подписываюсь на событие itemSwipe у реестра, то обработчик не срабатывает при правом свайпе, хотя у моего реестра отсутствует множественное выделение записей.
ОР:
Если у списочного контрола отключено множественное выделение - то правый свайп заставляет контрол инициировать соответствующее всплывающее событие, на которое можно установить свой обработчик