### PR TITLE
Документ №1181001881 от 2021-01-22 Сурмина М.С.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1660,7 +1660,6 @@ var
             current.getColspanForColumnScroll = () => _private.getColspanForColumnScroll(self);
             current.getColspanFor = (elementName: string) => self.getColspanFor.apply(self, [elementName]);
             current.stickyColumnsCount = this._options.stickyColumnsCount;
-
             current.rowSeparatorSize = this._options.rowSeparatorSize;
             current.columnSeparatorSize = this._options.columnSeparatorSize;
             if (current.hasMultiSelect) {
@@ -1892,7 +1891,8 @@ var
                         isSwiped: current.isSwiped,
                         getActions: current.getActions,
                         getContents: current.getContents,
-                        hasMultiSelectColumn: current.hasMultiSelectColumn
+                        hasMultiSelectColumn: current.hasMultiSelectColumn,
+                        task1181001881: self._options.task1181001881
                 };
                 currentColumn.classList = _private.getItemColumnCellClasses(self, current, current.theme, backgroundColorStyle);
 

--- a/Controls/_grid/_editArrowTemplate.wml
+++ b/Controls/_grid/_editArrowTemplate.wml
@@ -1,4 +1,5 @@
 <div class="controls-Grid__editArrow-wrapper_theme-{{_options.theme}}">
+      <div if="{{itemData.task1181001881 && itemData.column.textOverflow}}" class="controls-Grid__editArrow-withTextOverflow_theme-{{_options.theme}}"></div>
       <div class="controls-Grid__editArrow-blur_theme-{{_options.theme}} controls-Grid__editArrow-blur_style-{{itemData.style}}_background_theme-{{_options.theme}}"></div>
       <div on:click="_onEditArrowClick(itemData.item)"
            class="controls-Grid__editArrow_theme-{{_options.theme}} controls-Grid__editArrow_style-{{itemData.style}}_background_theme-{{_options.theme}}">

--- a/Controls/_grid/layout/grid/_Grid.less
+++ b/Controls/_grid/layout/grid/_Grid.less
@@ -961,15 +961,11 @@
 .controls-Grid__editArrow-overflow-ellipsis_theme-@{themeName} {
    margin-right: -@edit-arrow_icon-size_grid;
 }
-.controls-Grid__editArrow-separator_theme-@{themeName} {
+
+.controls-Grid__editArrow-withTextOverflow_theme-@{themeName} {
    flex-shrink: 1;
-   min-width: 0px;
-   width: @edit-arrow_offset_grid;
-}
-.controls-Grid__editArrow-separator-big_theme-@{themeName} {
-   flex-shrink: 1;
-   min-width: 0px;
-   width: @edit-arrow_offset_grid + @edit-arrow_icon-size_grid;
+   min-width: 0;
+   width: @edit-arrow_icon-size_grid;
 }
 
 .controls-Grid__cell_valign_top {


### PR DESCRIPTION
https://online.sbis.ru/doc/360195c8-d1e8-46ec-99e5-bead8bb4871b в справочнике маркета иконка ">>" наезжает на последнюю букву названия при ховере (скрин1)
Как повторить:  (см видео) Бизнес-маркет-Статистика-Номенклатуры-не распознано, поиск по "беби", клик по любому найденному, в открывшнмся мастере нажать "выбрать из справочника или связать с категорией", откроется панель справочника маркета, поводить мышкой над названиями категорий. провал в любую, поводить над названиями подкатегорий, смотри на иконку >>
ФР:  наезжает на последнюю букву названия
ОР:  есть отступ от названия до иконки
Страница: Маркет
Логин: Демо_тензор Пароль:   
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36
Версия:
online-inside_20.7260 (ver 20.7260) - 129 (22.01.2021 - 09:56:37)
Platforma 20.7200 - 201 (21.01.2021 - 17:44:32)
WS 20.7200 - 372 (20.01.2021 - 17:36:37)
Types 20.7200 - 372 (20.01.2021 - 17:36:37)
CONTROLS 20.7200 - 374 (21.01.2021 - 19:04:37)
SDK 20.7200 - 512 (21.01.2021 - 19:41:37)
DISTRIBUTION: inside
GenerateDate: 22.01.2021 - 09:56:37
autoerror_sbislogs 22.01.2021