### PR TITLE
Документ №1181001881 от 2021-01-22 Сурмина М.С.

### DIFF
--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -1895,8 +1895,7 @@ var
                         isSwiped: current.isSwiped,
                         getActions: current.getActions,
                         getContents: current.getContents,
-                        hasMultiSelectColumn: current.hasMultiSelectColumn,
-                        task1181001881: self._options.task1181001881
+                        hasMultiSelectColumn: current.hasMultiSelectColumn
                 };
                 currentColumn.classList = _private.getItemColumnCellClasses(self, current, current.theme, backgroundColorStyle);
 

--- a/Controls/_grid/_editArrowTemplate.wml
+++ b/Controls/_grid/_editArrowTemplate.wml
@@ -1,5 +1,5 @@
 <div class="controls-Grid__editArrow-wrapper_theme-{{_options.theme}}">
-      <div if="{{itemData.task1181001881 && itemData.column.textOverflow}}" class="controls-Grid__editArrow-withTextOverflow_theme-{{_options.theme}}"></div>
+      <div if="{{itemData.column.textOverflow}}" class="controls-Grid__editArrow-withTextOverflow_theme-{{_options.theme}}"></div>
       <div class="controls-Grid__editArrow-blur_theme-{{_options.theme}} controls-Grid__editArrow-blur_style-{{itemData.style}}_background_theme-{{_options.theme}}"></div>
       <div on:click="_onEditArrowClick(itemData.item)"
            class="controls-Grid__editArrow_theme-{{_options.theme}} controls-Grid__editArrow_style-{{itemData.style}}_background_theme-{{_options.theme}}">

--- a/Controls/_gridNew/Render/CellContent.wml
+++ b/Controls/_gridNew/Render/CellContent.wml
@@ -49,7 +49,7 @@
 
     <!-- Стрелка редактирования. Если шаблон прикладной, то не показываем -->
     <ws:if data="{{ !contentTemplate && (gridColumn || itemData).shouldDisplayEditArrow() && editArrowTemplate }}">
-        <ws:partial template="{{ editArrowTemplate }}" item="{{ (gridColumn || itemData).getOwner() }}"/>
+        <ws:partial template="{{ editArrowTemplate }}" item="{{ (gridColumn || itemData).getOwner() }}" textOverflow="{{(gridColumn || itemData).getColumnConfig().textOverflow}}"/>
     </ws:if>
 
     <!-- Тэг -->

--- a/Controls/_gridNew/Render/EditArrowTemplate.wml
+++ b/Controls/_gridNew/Render/EditArrowTemplate.wml
@@ -1,4 +1,5 @@
 <div class="controls-Grid__editArrow-wrapper_theme-{{_options.theme}}">
+      <div if="{{textOverflow}}" class="controls-Grid__editArrow-withTextOverflow_theme-{{_options.theme}}"></div>
       <div class="controls-Grid__editArrow-blur_theme-{{_options.theme}}"></div>
       <div on:click="_onEditArrowClick(item)"
            class="controls-Grid__editArrow_theme-{{_options.theme}}">

--- a/Controls/_treeGridNew/render/grid/Item.wml
+++ b/Controls/_treeGridNew/render/grid/Item.wml
@@ -34,7 +34,8 @@
                itemActionsClass="{{ itemActionsClass }}"
                templateHighlightOnHover="{{ templateHighlightOnHover }}"
                tagTemplate="{{ gridColumn.TagCell ? tagTemplate }}"
-               tagStyle="{{ gridColumn.TagCell ? tagStyle }}">
+               tagStyle="{{ gridColumn.TagCell ? tagStyle }}"
+               editArrowTemplate="{{ editArrowTemplate }}">
       <ws:ladderWrapper>
          <ws:partial template="{{ladderWrapper.content}}"
                      if="{{ (item || itemData).shouldDrawLadderContent(ladderWrapper.ladderProperty, ladderWrapper.stickyProperty) }}"
@@ -49,10 +50,6 @@
          </ws:partial>
       </ws:multiSelectTemplate>
    </ws:partial>
-
-   <ws:if data="{{ gridColumn.shouldDisplayEditArrow() }}">
-      <ws:partial template="{{ editArrowTemplate }}" item="{{ item || itemData }}"/>
-   </ws:if>
 
    <ws:if data="{{ gridColumn.ItemActionsCell && gridColumn.shouldDisplayItemActions() }}">
       <ws:if data="{{ (item || itemData).isSwiped() && itemActionsPosition !== 'outside' }}">


### PR DESCRIPTION
https://online.sbis.ru/doc/360195c8-d1e8-46ec-99e5-bead8bb4871b в справочнике маркета иконка ">>" наезжает на последнюю букву названия при ховере (скрин1)
Как повторить: (см видео) Бизнес-маркет-Статистика-Номенклатуры-не распознано, поиск по "беби", клик по любому найденному, в открывшнмся мастере нажать "выбрать из справочника или связать с категорией", откроется панель справочника маркета, поводить мышкой над названиями категорий. провал в любую, поводить над названиями подкатегорий, смотри на иконку >>
ФР: наезжает на последнюю букву названия
ОР: есть отступ от названия до иконки
Страница: Маркет
Логин: Демо_тензор Пароль:
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36
Версия:
online-inside_20.7260 (ver 20.7260) - 129 (22.01.2021 - 09:56:37)
Platforma 20.7200 - 201 (21.01.2021 - 17:44:32)
WS 20.7200 - 372 (20.01.2021 - 17:36:37)
Types 20.7200 - 372 (20.01.2021 - 17:36:37)
CONTROLS 20.7200 - 374 (21.01.2021 - 19:04:37)
SDK 20.7200 - 512 (21.01.2021 - 19:41:37)
DISTRIBUTION: inside
GenerateDate: 22.01.2021 - 09:56:37
autoerror_sbislogs 22.01.2021