### PR TITLE
Документ №1181321957 от 2021-03-01 Елкин К.В.

### DIFF
--- a/Controls/_display/Tree.ts
+++ b/Controls/_display/Tree.ts
@@ -908,9 +908,8 @@ export default class Tree<S extends Model = Model, T extends TreeItem<S> = TreeI
             nearbyItem = enumerator.getCurrent();
 
             // если мы пришли сюда, когда в enumerator ещё ничего нет, то nearbyItem будет undefined
-            // В 21.2000 Сделал проверку на SelectableItem
-            if ((skipGroups && !!nearbyItem && nearbyItem['[Controls/_display/GroupItem]']) ||
-                (!!nearbyItem && nearbyItem['[Controls/_display/SearchSeparator]'])) {
+            // если nearbyItem не может быть выделен, то он и не может стать текущим
+            if (!!nearbyItem && !nearbyItem.SelectableItem) {
                 nearbyItem = undefined;
                 continue;
             }


### PR DESCRIPTION
https://online.sbis.ru/doc/c5de763d-eb44-4c09-aa01-8a8ec3c9ea3f  ПРИЕМОЧНЫЕ автотесты. Не сохраняется поле введенного количества в каталоге когда добавляем наименование через поиск
Как повторить:  
Бизнес\Закупки\Поступления Документ+
Открыть каталог (из строки и по +), найти любое наименование
Ввести количество, сохранить по enter (или перейти в другое поле)
Повторяется на реализации
ФР:  Количество не сохранено (будет добавлено 1), ошибка в консоли:
CONTROL ERROR:  Ошибка при вызове обработчика "on:editingrowkeydown" из контрола Controls/list:BaseControl.
                     c.getParent is not a function IN "Controls/list:BaseControl"
ОР:  Количество сохранено, добавляется в документ указанное
Страница: Закупки/Расходы
Логин: аргус1 Пароль: Аргус123  
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.190 Safari/537.36
Версия:
online-inside_21.1200 (ver 21.1200) - 289 (01.03.2021 - 16:00:01)
Platforma 21.1200 - 117 (01.03.2021 - 06:57:00)
WS 21.1200 - 410 (01.03.2021 - 08:11:53)
Types 21.1200 - 410 (01.03.2021 - 08:11:53)
CONTROLS 21.1200 - 418 (01.03.2021 - 15:14:00)
SDK 21.1200 - 389 (01.03.2021 - 15:52:11)
DISTRIBUTION: ext
GenerateDate: 01.03.2021 - 16:00:01
autoerror_sbislogs 01.03.2021