### PR TITLE
21.1200/bugfix/apa/add sticky styles to ladder cell

### DIFF
--- a/Controls/_display/utils/GridLadderUtil.ts
+++ b/Controls/_display/utils/GridLadderUtil.ts
@@ -32,6 +32,7 @@ interface IPrepareLadderParams extends IStickyColumnsParams{
     startIndex: number;
     stopIndex: number;
     display: any;
+    hasColumnScroll?: boolean;
 
     task1181099336?: boolean;
 }
@@ -55,7 +56,8 @@ export function prepareLadder(params: IPrepareLadderParams): ILadderObject {
         supportSticky = !!stickyColumn,
         stickyProperties = [],
         ladder = {}, ladderState = {}, stickyLadder = {},
-        stickyLadderState = {};
+        stickyLadderState = {},
+        hasColumnScroll = params.hasColumnScroll;
 
     const nodeProperty = params.task1181099336 && params.display.getNodeProperty();
 
@@ -88,6 +90,12 @@ export function prepareLadder(params: IPrepareLadderParams): ILadderObject {
         processLadder(params);
         if (params.ladder.ladderLength && isFullGridSupport()) {
             params.ladder.headingStyle = 'grid-row: span ' + params.ladder.ladderLength;
+
+            // Для лесенки, если включен горизонтальный скролл, нужно делать z-index больше,
+            // чем у застиканных колонок. Иначе её содержимое будет находиться позади.
+            if (hasColumnScroll) {
+                params.ladder.headingStyle += '; z-index: 4;';
+            }
         }
     }
 

--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -271,9 +271,9 @@ var
         },
 
         isFixedCell: function(params) {
-            const { hasMultiSelectColumn, stickyColumnsCount, columnIndex, rowIndex, isHeader, isMultiHeader, endColumn } = params;
+            const { hasMultiSelectColumn, stickyColumnsCount, columnIndex, rowIndex, isHeader, isMultiHeader, endColumn, stickyLadderCellsCount } = params;
             const
-                columnOffset = hasMultiSelectColumn ? 1 : 0;
+                columnOffset = (hasMultiSelectColumn ? 1 : 0) + (stickyLadderCellsCount || 0);
 
             if (isHeader && typeof endColumn !== 'undefined') {
                 // endColumn - конфиг GridLayout, он всегда больше на 1.
@@ -294,7 +294,10 @@ var
         // сделаем перерисовку столбцов после установки isColumnScrollVisible
         getHeaderZIndex(params): number {
             if (params.columnScroll) {
-                return _private.isFixedCell(params) ? FIXED_HEADER_ZINDEX : STICKY_HEADER_ZINDEX;
+                // Если есть лесенка, то z-index заголовка стики-колонки надо увеличить на 1
+                return _private.isFixedCell(params) ?
+                    FIXED_HEADER_ZINDEX + (params.stickyLadderCellsCount ? 1 : 0) :
+                    STICKY_HEADER_ZINDEX;
             } else {
                 // Пока в таблице нет горизонтального скролла, шапка ен может быть проскролена по горизонтали.
                 return FIXED_HEADER_ZINDEX;
@@ -550,7 +553,8 @@ var
                 stopIndex,
                 display: self.getDisplay(),
                 columns: self._columns,
-                stickyColumn: self._options.stickyColumn
+                stickyColumn: self._options.stickyColumn,
+                hasColumnScroll: self._options.columnScroll
             });
             return newLadder;
         },
@@ -1082,6 +1086,7 @@ var
                   isMultiHeader: this._isMultiHeader,
                   hasMultiSelectColumn,
                   stickyColumnsCount: this._options.stickyColumnsCount,
+                  stickyLadderCellsCount: this.stickyLadderCellsCount(),
                    columnScroll: this._options.columnScroll
                });
             }
@@ -1098,7 +1103,8 @@ var
                     isHeader: true,
                     isMultiHeader: this._isMultiHeader,
                     hasMultiSelectColumn,
-                    stickyColumnsCount: this._options.stickyColumnsCount
+                    stickyColumnsCount: this._options.stickyColumnsCount,
+                    stickyLadderCellsCount: this.stickyLadderCellsCount()
                 };
                 cellClasses += _private.getColumnScrollCalculationCellClasses(params, this._options.theme);
                 cellClasses += _private.getColumnScrollCellClasses(params, this._options.theme);

--- a/Controls/_grid/GridViewModel.ts
+++ b/Controls/_grid/GridViewModel.ts
@@ -277,7 +277,7 @@ var
 
             if (isHeader && typeof endColumn !== 'undefined') {
                 // endColumn - конфиг GridLayout, он всегда больше на 1.
-                return endColumn - 1 <= stickyColumnsCount;
+                return endColumn - 1 <= stickyColumnsCount + (stickyLadderCellsCount || 0);
             }
             const isCellIndexLessTheFixedIndex = columnIndex < (stickyColumnsCount + columnOffset);
             if (isMultiHeader !== undefined) {

--- a/Controls/_grid/layout/grid/Item.wml
+++ b/Controls/_grid/layout/grid/Item.wml
@@ -98,7 +98,10 @@
 
 <ws:template name="STICKY_LADDER_HEADER">
    <ws:if data="{{itemData.stickyLadder[stickyProperty].headingStyle && currentColumn.hiddenForLadder}}">
-      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}"
+      <div attr:class="controls-Grid__row-ladder-cell
+                       {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}
+                       {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
+                       {{!!itemData.columnScroll ? currentColumn.classList.columnScroll}}"
            attr:key="{{itemData.key + stickyProperty + '_sticky_ladder'}}"
            attr:style="{{itemData.stickyLadder[stickyProperty].headingStyle}}">
 

--- a/Controls/_treeGrid/TreeGridView/layout/grid/Item.wml
+++ b/Controls/_treeGrid/TreeGridView/layout/grid/Item.wml
@@ -162,7 +162,10 @@
 
 <ws:template name="STICKY_LADDER_HEADER">
    <ws:if data="{{itemData.stickyLadder[stickyProperty].headingStyle && currentColumn.hiddenForLadder}}">
-      <div attr:class="controls-Grid__row-ladder-cell {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}{{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}"
+      <div attr:class="controls-Grid__row-ladder-cell
+                       {{!!itemData.isActive() ? ' controls-GridView__item_active_theme-' + itemData.theme}}
+                       {{!!itemData.isDragging ? ' controls-ListView__item_dragging_theme-' + itemData.theme}}
+                       {{!!itemData.columnScroll ? currentColumn.classList.columnScroll}}"
            attr:key="{{itemData.key + stickyProperty + '_sticky_ladder'}}"
            attr:style="{{itemData.stickyLadder[stickyProperty].headingStyle}}">
 

--- a/tests/ControlsUnit/List/Grid/GridLadderUtil.test.js
+++ b/tests/ControlsUnit/List/Grid/GridLadderUtil.test.js
@@ -229,4 +229,33 @@ define(['Types/collection', 'Controls/display', 'Env/Env'], function(Collection,
          assert.deepEqual(ladder.stickyLadder, resultStickyLadder, 'Incorrect value prepared stickyLadder.');
       });
    });
+
+   it('should return z-index styles for sticky column', () => {
+      const items = new Collection.RecordSet({
+         keyProperty: 'key',
+         rawData: [
+            { key: 0, title: 'i0', first: 1, second: 1 },
+            { key: 1, title: 'i1', first: 2, second: 1 },
+            { key: 2, title: 'i2', first: 3, second: 2 },
+            { key: 3, title: 'i3', first: 3, second: 2 }
+         ]
+      });
+      const columns = [
+         {
+            width: '1fr',
+            displayProperty: 'title',
+            stickyProperty: ['first', 'second']
+         }];
+      const display = new Display.Collection({ collection: items, keyProperty: 'id' });
+      const ladder = Util.prepareLadder({
+         display,
+         columns: columns,
+         ladderProperties: ['first', 'second'],
+         startIndex: 0,
+         stopIndex: 4,
+         hasColumnScroll: true
+      });
+
+      assert.equal(ladder.stickyLadder[0].first.headingStyle, 'grid-row: span 1; z-index: 4;');
+   });
 });

--- a/tests/ControlsUnit/List/Grid/GridView.test.js
+++ b/tests/ControlsUnit/List/Grid/GridView.test.js
@@ -534,6 +534,7 @@ define(['Controls/grid', 'Types/collection'], function(gridMod, collection) {
          describe('update sizes', () => {
             it('on view resize', async () => {
                gridView.saveOptions(cfg);
+               gridView._beforeMount(cfg);
                gridView._afterMount();
 
                await new Promise((resolve) => {
@@ -551,6 +552,7 @@ define(['Controls/grid', 'Types/collection'], function(gridMod, collection) {
 
             it('on list collection changed', async () => {
                gridView.saveOptions(cfg);
+               gridView._beforeMount(cfg);
                gridView._afterMount();
 
                await new Promise((resolve) => {
@@ -568,6 +570,7 @@ define(['Controls/grid', 'Types/collection'], function(gridMod, collection) {
 
             it('on toggle multiselect', async () => {
                gridView.saveOptions({...cfg, multiSelectVisibility: 'hidden'});
+               gridView._beforeMount(cfg);
                gridView._afterMount();
 
                assert.equal(gridView._containerSize, 100);
@@ -694,6 +697,7 @@ define(['Controls/grid', 'Types/collection'], function(gridMod, collection) {
 
 
                gridView.saveOptions(cfg);
+               gridView._beforeMount(cfg);
                await gridView._afterMount();
                gridView._notify = (eName, args) => {
                   if (eName === 'itemSwipe') {

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -2279,6 +2279,39 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             })
             assert.isFalse(secondRow);
          });
+
+         it('sticky ladder cells should be fixed', () => {
+            var firstRow = gridMod.GridViewModel._private.isFixedCell({
+               multiSelectVisibility: false,
+               stickyColumnsCount: 1,
+               columnIndex: 1,
+               rowIndex: 0,
+               isMultiHeader: true,
+               stickyLadderCellsCount: 2
+            });
+            assert.isTrue(firstRow);
+
+            var firstRow = gridMod.GridViewModel._private.isFixedCell({
+               multiSelectVisibility: false,
+               stickyColumnsCount: 1,
+               columnIndex: 2,
+               rowIndex: 0,
+               isMultiHeader: true,
+               stickyLadderCellsCount: 2
+            });
+            assert.isTrue(firstRow);
+
+            var secondRow = gridMod.GridViewModel._private.isFixedCell({
+               multiSelectVisibility: false,
+               stickyColumnsCount: 1,
+               columnIndex: 3,
+               rowIndex: 1,
+               isMultiHeader: true,
+               stickyLadderCellsCount: 2
+            });
+            assert.isFalse(secondRow);
+         });
+
          it('update version if column scroll visibility has been changed', function () {
             const testModel = new gridMod.GridViewModel({
                ...cfg,
@@ -3025,6 +3058,23 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             assert.equal(4, gridMod.GridViewModel._private.getHeaderZIndex({...params, columnScroll: false}));
             // sticky fit coll withoutColumnScroll
             assert.equal(4, gridMod.GridViewModel._private.getHeaderZIndex({...params, columnScroll: false, columnIndex: 1}));
+         });
+
+         it('getHeaderZIndex with or columnScroll and ladder', function() {
+            const params = {
+               multiSelectVisibility: 'hidden',
+               stickyColumnsCount: 1,
+               columnIndex: 0,
+               rowIndex: 0,
+               isMultiHeader: false,
+               columnScroll: true,
+               isColumnScrollVisible: true,
+               stickyLadderCellsCount: 2
+            };
+            // fixed coll with columnScroll
+            assert.equal(5, gridMod.GridViewModel._private.getHeaderZIndex(params));
+            // sticky coll with columnScroll
+            assert.equal(3, gridMod.GridViewModel._private.getHeaderZIndex({...params, columnIndex: 1}));
          });
 
          it('updates prefix version with ladder only on add and remove', () => {

--- a/tests/ControlsUnit/List/Grid/GridViewModel.test.js
+++ b/tests/ControlsUnit/List/Grid/GridViewModel.test.js
@@ -3074,7 +3074,7 @@ define(['Controls/grid', 'Core/core-merge', 'Types/collection', 'Types/entity', 
             // fixed coll with columnScroll
             assert.equal(5, gridMod.GridViewModel._private.getHeaderZIndex(params));
             // sticky coll with columnScroll
-            assert.equal(3, gridMod.GridViewModel._private.getHeaderZIndex({...params, columnIndex: 1}));
+            assert.equal(3, gridMod.GridViewModel._private.getHeaderZIndex({...params, columnIndex: 3}));
          });
 
          it('updates prefix version with ladder only on add and remove', () => {


### PR DESCRIPTION
https://online.sbis.ru/doc/d0d9049c-af1d-47fe-8acc-f4836193ec11 При скроллировании таблицы с установленным горизонтальным объединением колонок заголовок становится прозрачным
Воспроизводится в таблице с лесенкой и прилипанием данных