### PR TITLE
Документ №1181457061 от 2021-03-18 Варенышев А.А.

### DIFF
--- a/Controls/_display/Collection.ts
+++ b/Controls/_display/Collection.ts
@@ -3665,7 +3665,6 @@ export default class Collection<S extends EntityModel = EntityModel, T extends C
             return;
         }
         const groupStrategy = this._composer.getInstance<GroupItemsStrategy<S, T>>(GroupItemsStrategy);
-        // Если происходит пересоздание групп, надо актуализировать collapsedGroups
         groupStrategy.collapsedGroups = this._$collapsedGroups;
         groupStrategy.invalidate();
     }

--- a/Controls/_display/Collection.ts
+++ b/Controls/_display/Collection.ts
@@ -3665,6 +3665,8 @@ export default class Collection<S extends EntityModel = EntityModel, T extends C
             return;
         }
         const groupStrategy = this._composer.getInstance<GroupItemsStrategy<S, T>>(GroupItemsStrategy);
+        // Если происходит пересоздание групп, надо актуализировать collapsedGroups
+        groupStrategy.collapsedGroups = this._$collapsedGroups;
         groupStrategy.invalidate();
     }
 

--- a/Controls/_display/Collection.ts
+++ b/Controls/_display/Collection.ts
@@ -2717,18 +2717,7 @@ export default class Collection<S extends EntityModel = EntityModel, T extends C
     }
 
     getCollapsedGroups(): TArrayGroupKey {
-        // TODO зарефакторить https://online.sbis.ru/opendoc.html?guid=e20934c7-95fa-44f3-a7c2-c2a3ec32e8a3
-        if (this._$collapsedGroups) {
-            return this._$collapsedGroups;
-        } else {
-            const collapsedGroups = [];
-            this.each((it) => {
-                if (it['[Controls/_display/GroupItem]'] && !it.isExpanded()) {
-                    collapsedGroups.push(it.getContents());
-                }
-            });
-            return collapsedGroups;
-        }
+        return this._$collapsedGroups;
     }
 
     setCollapsedGroups(collapsedGroups: TArrayGroupKey): void {
@@ -3665,6 +3654,14 @@ export default class Collection<S extends EntityModel = EntityModel, T extends C
             return;
         }
         const groupStrategy = this._composer.getInstance<GroupItemsStrategy<S, T>>(GroupItemsStrategy);
+        // prependStrategy вызывает _reGroup после composer.prepend().
+        // Внутри composer.prepend() имеющийся экземпляр стратегии удаляется, и пересоздаётся с опциями,
+        // которые были переданы для неё при добавлении в компоновщик.
+        // Необходимо устанавливать актуальное состояние "свёрнутости" групп,
+        // т.к. после пересоздания стратегии, она ничего не знает об актуальном значении collapsedGroups.
+        // Чтобы убрать этот костыль, надо или научить компоновщик пересоздавать стратегии с актуальными опциями
+        // или сделать получение collapsedGroups через callback или пересмотреть необходимость пересоздания
+        // стратегий при prepend.
         groupStrategy.collapsedGroups = this._$collapsedGroups;
         groupStrategy.invalidate();
     }

--- a/Controls/_display/itemsStrategy/Group.ts
+++ b/Controls/_display/itemsStrategy/Group.ts
@@ -100,10 +100,13 @@ export default class Group<S, T extends CollectionItem<S> = CollectionItem<S>> e
     }
 
     set collapsedGroups(value: IGroups) {
+        const valueChanged = this._options.collapsedGroups !== value;
         this._options.collapsedGroups = value;
-        // reset created groups
-        this._groups = [];
-        this._itemsOrder = null;
+        if (valueChanged) {
+            // reset created groups
+            this._groups = [];
+            this._itemsOrder = null;
+        }
     }
 
     get groups(): Array<GroupItem<IGroup>> {

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -5014,10 +5014,6 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
         }
     },
 
-    _updateCollapsedGroups(): void {
-
-    },
-
     isLoading(): boolean {
         return this._sourceController && this._sourceController.isLoading();
     },

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -4990,6 +4990,11 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
                     group: groupId,
                     collapsedGroups
                 };
+                // При setExpanded() не обновляется collection.collapsedGroups.
+                // При collection.reBuild в стратегию группы будет передано текущее значение collapsedGroups и
+                // при пересоздании группы её актуальное состояние развёрнутости не будет учитываться.
+                // Поэтому тут нужно изменить текущее значение списка свёрнутых групп.
+                collection.setCollapsedGroups(collapsedGroups);
                 _private.groupsExpandChangeHandler(this, changes);
             } else {
                 const needExpandGroup = !collection.isGroupExpanded(groupId);

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -4990,10 +4990,8 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
                     group: groupId,
                     collapsedGroups
                 };
-                // При setExpanded() не обновляется collection.collapsedGroups.
-                // При collection.reBuild в стратегию группы будет передано текущее значение collapsedGroups и
-                // при пересоздании группы её актуальное состояние развёрнутости не будет учитываться.
-                // Поэтому тут нужно изменить текущее значение списка свёрнутых групп.
+                // При setExpanded() не обновляется collection.collapsedGroups, на основе которого стратегия
+                // определяет, какие группы надо создавать свёрнутыми. Поэтому обновляем его тут.
                 collection.setCollapsedGroups(collapsedGroups);
                 _private.groupsExpandChangeHandler(this, changes);
             } else {
@@ -5014,6 +5012,10 @@ const BaseControl = Control.extend(/** @lends Controls/_list/BaseControl.prototy
                 }
             }
         }
+    },
+
+    _updateCollapsedGroups(): void {
+
     },
 
     isLoading(): boolean {

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -3864,6 +3864,52 @@ define([
             });
          });
       });
+
+      describe('_onGroupClick', () => {
+         let ctrl;
+         const cfg = {
+            viewName: 'Controls/List/ListView',
+            viewModelConstructor: 'Controls/display:Collection',
+            useNewModel: true,
+            keyProperty: 'id',
+            groupProperty: 'group',
+            source: new sourceLib.Memory({
+               keyProperty: 'id',
+               data: [
+                  {
+                     id: 1,
+                     title: 'item 1',
+                     group: 'group'
+                  },
+                  {
+                     id: 2,
+                     title: 'item 2',
+                     group: 'group'
+                  }
+               ]
+            })
+         };
+
+         beforeEach(() => {
+            ctrl = correctCreateBaseControl(cfg);
+            ctrl.saveOptions(cfg);
+         });
+
+         it('should call setCollapsedGroups', (done) => {
+            ctrl._beforeMount(cfg).then(() => {
+               const spySetCollapsedGroups = sinon.spy(ctrl.getViewModel(), 'setCollapsedGroups');
+               ctrl._onGroupClick({}, 0, {
+                  target: {
+                     closest: () => true
+                  }
+               }, ctrl.getViewModel().at(0));
+               sinon.assert.called(spySetCollapsedGroups);
+               spySetCollapsedGroups.restore();
+               done();
+            });
+         });
+      });
+
       it('can\'t start drag on readonly list', function() {
          let
              cfg = {

--- a/tests/ControlsUnit/display/Collection.test.ts
+++ b/tests/ControlsUnit/display/Collection.test.ts
@@ -4769,25 +4769,4 @@ describe('Controls/_display/Collection', () => {
             assert.equal(display.getHoverBackgroundStyle(), 'master');
         });
     });
-
-    describe('groups', () => {
-        it('getCollapsedGroups', () => {
-            const items = [
-                {id: 1, group: 1},
-                {id: 2, group: 2}
-            ];
-            const display = new CollectionDisplay({
-                collection: new RecordSet({
-                    rawData: items,
-                    keyProperty: 'id'
-                }),
-                keyProperty: 'id',
-                group: (item) => item.get('group')
-            });
-
-            display.at(0).setExpanded(false);
-
-            assert.deepEqual(display.getCollapsedGroups(), [1]);
-        });
-    });
 });


### PR DESCRIPTION
https://online.sbis.ru/doc/c8afa034-5a23-4170-815a-f11a94c404f5  При попытке добавить наименование в табличную часть с группами падает ошибка в консоль
Как повторить:  
фикс
Бизнес - закупки
документ оприходования 31
нажать снизу ТЧ "+ наименование"
свернуть группу
ФР:  
1. При нажатии "+ наименование" развернулись товарные группы
2. CONTROL ERROR:  Ошибка при вызове обработчика "on:groupclick" из контрола Controls/list:BaseControl.
                     e.toggleGroup is not a function IN "Controls/list:BaseControl"
 ↱ Controls/dataSource:error.Container
  ↱ Controls/list:BaseControl
ОР:  
Товарные группы не разворачиваются
нет ошибки в консоль
Страница: Закупки/Расходы
Логин: гремлины123 Пароль: Гремлины123  
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36
Версия:
online-inside_21.1213 (ver 21.1213) - 77 (18.03.2021 - 09:41:18)
Platforma 21.1200 - 179 (17.03.2021 - 16:14:42)
WS 21.1200 - 523 (15.03.2021 - 19:40:21)
Types 21.1200 - 534 (17.03.2021 - 15:50:14)
CONTROLS 21.1200 - 537 (17.03.2021 - 23:02:06)
SDK 21.1200 - 533 (17.03.2021 - 23:37:50)
DISTRIBUTION: ext
GenerateDate: 18.03.2021 - 09:41:18
autoerror_sbislogs 18.03.2021