### PR TITLE
Документ №1181457061 от 2021-03-18 Варенышев А.А

### DIFF
--- a/Controls/_display/itemsStrategy/Group.ts
+++ b/Controls/_display/itemsStrategy/Group.ts
@@ -100,10 +100,13 @@ export default class Group<S, T extends CollectionItem<S> = CollectionItem<S>> e
     }
 
     set collapsedGroups(value: IGroups) {
+        const valueChanged = this._options.collapsedGroups !== value;
         this._options.collapsedGroups = value;
-        // reset created groups
-        this._groups = [];
-        this._itemsOrder = null;
+        if (valueChanged) {
+            // reset created groups
+            this._groups = [];
+            this._itemsOrder = null;
+        }
     }
 
     get groups(): Array<GroupItem<IGroup>> {

--- a/Controls/_list/BaseControl.ts
+++ b/Controls/_list/BaseControl.ts
@@ -5045,6 +5045,9 @@ export class BaseControl<TOptions extends IBaseControlOptions = IBaseControlOpti
                     group: groupId,
                     collapsedGroups
                 };
+                // При setExpanded() не обновляется collection.collapsedGroups, на основе которого стратегия
+                // определяет, какие группы надо создавать свёрнутыми. Поэтому обновляем его тут.
+                collection.setCollapsedGroups(collapsedGroups);
                 _private.groupsExpandChangeHandler(this, changes);
             } else {
                 const needExpandGroup = !collection.isGroupExpanded(groupId);

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -3888,18 +3888,16 @@ define([
             ctrl.saveOptions(cfg);
          });
 
-         it('should call setCollapsedGroups', (done) => {
-            ctrl._beforeMount(cfg).then(() => {
-               const spySetCollapsedGroups = sinon.spy(ctrl.getViewModel(), 'setCollapsedGroups');
-               ctrl._onGroupClick({}, 0, {
-                  target: {
-                     closest: () => true
-                  }
-               }, ctrl.getViewModel().at(0));
-               sinon.assert.called(spySetCollapsedGroups);
-               spySetCollapsedGroups.restore();
-               done();
-            });
+         it('should call setCollapsedGroups', () => {
+            ctrl._beforeMount(cfg);
+            const spySetCollapsedGroups = sinon.spy(ctrl.getViewModel(), 'setCollapsedGroups');
+            ctrl._onGroupClick({}, 0, {
+               target: {
+                  closest: () => true
+               }
+            }, ctrl.getViewModel().at(0));
+            sinon.assert.called(spySetCollapsedGroups);
+            spySetCollapsedGroups.restore();
          });
       });
 

--- a/tests/ControlsUnit/List/BaseControl.test.js
+++ b/tests/ControlsUnit/List/BaseControl.test.js
@@ -3857,6 +3857,52 @@ define([
             });
          });
       });
+
+      describe('_onGroupClick', () => {
+         let ctrl;
+         const cfg = {
+            viewName: 'Controls/List/ListView',
+            viewModelConstructor: 'Controls/display:Collection',
+            useNewModel: true,
+            keyProperty: 'id',
+            groupProperty: 'group',
+            source: new sourceLib.Memory({
+               keyProperty: 'id',
+               data: [
+                  {
+                     id: 1,
+                     title: 'item 1',
+                     group: 'group'
+                  },
+                  {
+                     id: 2,
+                     title: 'item 2',
+                     group: 'group'
+                  }
+               ]
+            })
+         };
+
+         beforeEach(() => {
+            ctrl = correctCreateBaseControl(cfg);
+            ctrl.saveOptions(cfg);
+         });
+
+         it('should call setCollapsedGroups', (done) => {
+            ctrl._beforeMount(cfg).then(() => {
+               const spySetCollapsedGroups = sinon.spy(ctrl.getViewModel(), 'setCollapsedGroups');
+               ctrl._onGroupClick({}, 0, {
+                  target: {
+                     closest: () => true
+                  }
+               }, ctrl.getViewModel().at(0));
+               sinon.assert.called(spySetCollapsedGroups);
+               spySetCollapsedGroups.restore();
+               done();
+            });
+         });
+      });
+
       it('can\'t start drag on readonly list', async function() {
          let
              cfg = {

--- a/tests/ControlsUnit/display/Collection.test.ts
+++ b/tests/ControlsUnit/display/Collection.test.ts
@@ -4431,25 +4431,4 @@ describe('Controls/_display/Collection', () => {
             assert.equal(display.getHoverBackgroundStyle(), 'master');
         });
     });
-
-    describe('groups', () => {
-        it('getCollapsedGroups', () => {
-            const items = [
-                {id: 1, group: 1},
-                {id: 2, group: 2}
-            ];
-            const display = new CollectionDisplay({
-                collection: new RecordSet({
-                    rawData: items,
-                    keyProperty: 'id'
-                }),
-                keyProperty: 'id',
-                group: (item) => item.get('group')
-            });
-
-            display.at(0).setExpanded(false);
-
-            assert.deepEqual(display.getCollapsedGroups(), [1]);
-        });
-    });
 });


### PR DESCRIPTION
https://online.sbis.ru/doc/c8afa034-5a23-4170-815a-f11a94c404f5 При попытке добавить наименование в табличную часть с группами падает ошибка в консоль
Как повторить: 
фикс
Бизнес - закупки
документ оприходования 31
нажать снизу ТЧ "+ наименование"
свернуть группу
ФР: 

При нажатии "+ наименование" развернулись товарные группы
CONTROL ERROR:  Ошибка при вызове обработчика "on:groupclick" из контрола Controls/list:BaseControl.
                     e.toggleGroup is not a function IN "Controls/list:BaseControl"
↱ Controls/dataSource:error.Container
  ↱ Controls/list:BaseControl
ОР: 
Товарные группы не разворачиваются
нет ошибки в консоль
Страница: Закупки/Расходы
Логин: гремлины123 Пароль: Гремлины123 
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36
Версия:
online-inside_21.1213 (ver 21.1213) - 77 (18.03.2021 - 09:41:18)
Platforma 21.1200 - 179 (17.03.2021 - 16:14:42)
WS 21.1200 - 523 (15.03.2021 - 19:40:21)
Types 21.1200 - 534 (17.03.2021 - 15:50:14)
CONTROLS 21.1200 - 537 (17.03.2021 - 23:02:06)
SDK 21.1200 - 533 (17.03.2021 - 23:37:50)
DISTRIBUTION: ext
GenerateDate: 18.03.2021 - 09:41:18
autoerror_sbislogs 18.03.2021