### PR TITLE
Документ №1181516938 от 2021-03-25 Елкин К.В.

### DIFF
--- a/Controls/_itemActions/Controller.ts
+++ b/Controls/_itemActions/Controller.ts
@@ -895,7 +895,8 @@ export class Controller {
         for (let i = 0; i < length; i++) {
             if (
                 aActions[i].id !== bActions[i].id ||
-                aActions[i].icon !== bActions[i].icon
+                aActions[i].icon !== bActions[i].icon ||
+                aActions[i].showType !== bActions[i].showType
             ) {
                 return false;
             }

--- a/tests/ControlsUnit/itemActions/Controller.test.ts
+++ b/tests/ControlsUnit/itemActions/Controller.test.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {stub, SinonStub} from 'sinon';
+import {stub, SinonStub, spy, assert as sinonAssert} from 'sinon';
 import {Model, Record} from 'Types/entity';
 import {RecordSet} from 'Types/collection';
 import {SyntheticEvent} from 'Vdom/Vdom';
@@ -510,6 +510,26 @@ describe('Controls/_itemActions/Controller', () => {
         //  знать о группах
         //  надо разобраться как в коллекцию добавить group
         // it('should set item actions when some items are groups', () => {});
+
+        it('should call collection.setActions() when itemAction\'s showType has changed', () => {
+            const newItemActions = itemActions.map((itemAction: IItemAction) => {
+                const itemActionClone: IItemAction = {...itemAction};
+                if (itemActionClone.showType === TItemActionShowType.TOOLBAR) {
+                    itemActionClone.showType = TItemActionShowType.MENU_TOOLBAR;
+                }
+                return itemActionClone;
+            });
+            const item3 = collection.getItemBySourceKey(3);
+            const spySetActions = spy(item3, 'setActions');
+            // @ts-ignore
+            itemActionsController.update(initializeControllerOptions({
+                collection,
+                itemActions: newItemActions,
+                theme: 'default'
+            }));
+            sinonAssert.called(spySetActions);
+            spySetActions.restore();
+        });
     });
 
     // T2. Активация и деактивация Swipe происходит корректно


### PR DESCRIPTION
https://online.sbis.ru/doc/df6d5ba7-7377-470b-bb18-29e2c4fc6d73  ПРИЕМОЧНЫЕ автотесты. Не соответствует набор операций над вложением в просмотрщике
Как повторить:
Бизнес\Закупки\Поступления\ Документ +
Прикрепить картинку (проверить на складской вкладке и на вкладке документы)
Повторяется на реализации
ФР:  В документе на просмотр и редактирования - на весь экран, скачать, три точки
ОР: Из надошибки:
1.1 Режим редактирования - на весь экран, удалить, три точки
1.2 Режим просмотра - на весь экран, скачать, три точки
Страница: Закупки/Расходы
Логин: аргус1 Пароль: Аргус123
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36
Версия:
online-inside_21.1220 (ver 21.1220) - 141 (25.03.2021 - 01:02:36)
Platforma 21.1200 - 217 (24.03.2021 - 18:06:17)
WS 21.1200 - 523 (15.03.2021 - 19:40:21)
Types 21.1200 - 534 (17.03.2021 - 15:50:14)
CONTROLS 21.1200 - 571 (24.03.2021 - 18:50:41)
SDK 21.1200 - 581 (24.03.2021 - 19:43:25)
DISTRIBUTION: ext
GenerateDate: 25.03.2021 - 01:02:36
autoerror_sbislogs 25.03.2021