### PR TITLE
Документ №1181610296 от 2021-04-05 Акимова И.С.

### DIFF
--- a/Controls/_tree/TreeControl.ts
+++ b/Controls/_tree/TreeControl.ts
@@ -592,7 +592,7 @@ export class TreeControl<TOptions extends ITreeControlOptions = ITreeControlOpti
      */
     private _shouldLoadLastExpandedNodeData(direction: Direction, item: TreeItem, parentKey: CrudEntityKey): boolean {
         // Иногда item это breadcrumbsItemRow, он не TreeItem
-        if (!item || item['[Controls/_display/TreeItem]'] || direction !== 'down') {
+        if (!item || !item['[Controls/_display/TreeItem]'] || direction !== 'down') {
             return false;
         }
         const hasMoreParentData = this._sourceController.hasMoreData('down', parentKey);

--- a/Controls/_tree/TreeControl.ts
+++ b/Controls/_tree/TreeControl.ts
@@ -591,7 +591,8 @@ export class TreeControl<TOptions extends ITreeControlOptions = ITreeControlOpti
      * @private
      */
     private _shouldLoadLastExpandedNodeData(direction: Direction, item: TreeItem, parentKey: CrudEntityKey): boolean {
-        if (!item || direction !== 'down') {
+        // Иногда item это breadcrumbsItemRow, он не TreeItem
+        if (!item || item['[Controls/_display/TreeItem]'] || direction !== 'down') {
             return false;
         }
         const hasMoreParentData = this._sourceController.hasMoreData('down', parentKey);

--- a/tests/ControlsUnit/Tree/TreeControl/LastExpandedNode.test.ts
+++ b/tests/ControlsUnit/Tree/TreeControl/LastExpandedNode.test.ts
@@ -5,10 +5,10 @@ import { TreeGridCollection } from 'Controls/treeGridNew';
 import { register } from 'Types/di';
 import { assert } from 'chai';
 import { stub, spy, assert as sinonAssert } from 'sinon';
-import {Search} from 'Controls/display';
+import {SearchGridCollection} from 'Controls/searchBreadcrumbsGrid';
 
 register('Controls/treeGrid:TreeGridCollection', TreeGridCollection, {instantiate: false});
-register('Controls/display:Search', Search, {instantiate: false});
+register('Controls/searchBreadcrumbsGrid:SearchGridCollection', SearchGridCollection, {instantiate: false});
 
 describe('Controls/Tree/TreeControl/LastExpandedNode', () => {
     let source: HierarchicalMemory;
@@ -175,15 +175,16 @@ describe('Controls/Tree/TreeControl/LastExpandedNode', () => {
         spyQuery.restore();
     });
 
-    it ('should not try to load and fall with non TreeItem', async () => {
+    it ('should not try loading for BreadcrumbsItem', async () => {
         source = new HierarchicalMemory({
             keyProperty: 'id',
             data
         });
 
         const spyQuery = spy(source, 'query');
+        // Инициализируем TreeControl с поисковой моделью (чтобы получть Breadcrumbs)
         const treeControl = initTreeControl({
-            viewModelConstructor: 'Controls/display:Search'
+            viewModelConstructor: 'Controls/searchBreadcrumbsGrid:SearchGridCollection'
         });
 
         await treeControl.handleTriggerVisible('down');

--- a/tests/ControlsUnit/Tree/TreeControl/LastExpandedNode.test.ts
+++ b/tests/ControlsUnit/Tree/TreeControl/LastExpandedNode.test.ts
@@ -5,8 +5,10 @@ import { TreeGridCollection } from 'Controls/treeGridNew';
 import { register } from 'Types/di';
 import { assert } from 'chai';
 import { stub, spy, assert as sinonAssert } from 'sinon';
+import {Search} from 'Controls/display';
 
 register('Controls/treeGrid:TreeGridCollection', TreeGridCollection, {instantiate: false});
+register('Controls/display:Search', Search, {instantiate: false});
 
 describe('Controls/Tree/TreeControl/LastExpandedNode', () => {
     let source: HierarchicalMemory;
@@ -167,6 +169,22 @@ describe('Controls/Tree/TreeControl/LastExpandedNode', () => {
             nodeFooterTemplate: () => {}
         });
         treeControl.toggleExpanded('2');
+
+        await treeControl.handleTriggerVisible('down');
+        sinonAssert.notCalled(spyQuery);
+        spyQuery.restore();
+    });
+
+    it ('should not fall with non TreeItem', async () => {
+        source = new HierarchicalMemory({
+            keyProperty: 'id',
+            data
+        });
+
+        const spyQuery = spy(source, 'query');
+        const treeControl = initTreeControl({
+            viewModelConstructor: 'Controls/display:Search'
+        });
 
         await treeControl.handleTriggerVisible('down');
         sinonAssert.notCalled(spyQuery);

--- a/tests/ControlsUnit/Tree/TreeControl/LastExpandedNode.test.ts
+++ b/tests/ControlsUnit/Tree/TreeControl/LastExpandedNode.test.ts
@@ -175,7 +175,7 @@ describe('Controls/Tree/TreeControl/LastExpandedNode', () => {
         spyQuery.restore();
     });
 
-    it ('should not fall with non TreeItem', async () => {
+    it ('should not try to load and fall with non TreeItem', async () => {
         source = new HierarchicalMemory({
             keyProperty: 'id',
             data

--- a/tests/ControlsUnit/grid_clean/Display/Ladder/BackgroundStyle.test.ts
+++ b/tests/ControlsUnit/grid_clean/Display/Ladder/BackgroundStyle.test.ts
@@ -12,7 +12,7 @@ describe('Controls/grid_clean/Display/DataCell/BackgroundStyle.test.ts', () => {
         getLeftPadding: () => 'default',
         getRightPadding: () => 'default',
         getEditingConfig: () => ({
-            mode: 'cell'
+            mode: 'cel
         }),
         getColumnIndex: () => 0,
         getColumnsCount: () => 0,

--- a/tests/ControlsUnit/grid_clean/Display/Ladder/BackgroundStyle.test.ts
+++ b/tests/ControlsUnit/grid_clean/Display/Ladder/BackgroundStyle.test.ts
@@ -12,7 +12,7 @@ describe('Controls/grid_clean/Display/DataCell/BackgroundStyle.test.ts', () => {
         getLeftPadding: () => 'default',
         getRightPadding: () => 'default',
         getEditingConfig: () => ({
-            mode: 'cel
+            mode: 'cell'
         }),
         getColumnIndex: () => 0,
         getColumnsCount: () => 0,


### PR DESCRIPTION
https://online.sbis.ru/doc/cbd2688a-9e16-4396-ba20-2f6252c9a713  Интеграция/Касса: Ошибка в консоли при поиске в реестре р/счетов
Как повторить:
Деньги/Банк - Р/счета
Ввести значение в строку поиска
Найти
ФР:
Отображаются результаты поиска, ошибки в консоли:
Uncaught (in promise) TypeError: t.isNode is not a function
Stack: TypeError: e.setSearchValue is not a function
ОР:
Поиск работает без ошибок
Страница: Расчетные счета
Логин: иринаа Пароль:   Ирина1234
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36
Версия:
online-inside_21.2100 (ver 21.2100) - 984 (05.04.2021 - 08:00:01)
Platforma 21.2000 - 647 (04.04.2021 - 17:37:26)
WS 21.2000 - 949 (05.04.2021 - 06:51:00)
Types 21.2000 - 949 (05.04.2021 - 06:51:00)
CONTROLS 21.2000 - 949 (05.04.2021 - 06:51:00)
SDK 21.2000 - 1208 (05.04.2021 - 07:45:17)
DISTRIBUTION: ext
GenerateDate: 05.04.2021 - 08:00:01
autoerror_sbislogs 05.04.2021