### PR TITLE
Документ №1181493897 от 2021-03-23 Путилова М.С.

### DIFF
--- a/Controls/_grid/Render/CellContent.wml
+++ b/Controls/_grid/Render/CellContent.wml
@@ -22,11 +22,11 @@
                     <ws:content>
                         <ws:if data="{{ (gridColumn || itemData).hasCellContentRender() }}">
                             <!-- Контент по умолчанию, обрезка длинного текста с многоточием -->
-                            <div class="controls-Grid__cell_{{(gridColumn || itemData).config.textOverflow}}">
-                                <ws:partial template="{{(gridColumn || itemData).getCellContentRender()}}"
-                                            value="{{(gridColumn || itemData).getDefaultDisplayValue()}}"
-                                            searchValue="{{(gridColumn || itemData).getSearchValue()}}"
-                                            scope="{{(gridColumn || itemData).config}}"/>
+                            <div class="{{ (gridColumn || itemData).getTextOverflowClasses() }}">
+                                <ws:partial template="{{ (gridColumn || itemData).getCellContentRender() }}"
+                                            value="{{ (gridColumn || itemData).getDefaultDisplayValue() }}"
+                                            searchValue="{{ (gridColumn || itemData).getSearchValue() }}"
+                                            scope="{{ (gridColumn || itemData).config }}"/>
                             </div>
                         </ws:if>
                         <ws:else>
@@ -43,8 +43,9 @@
         <ws:else>
             <ws:if data="{{ (gridColumn || itemData).hasCellContentRender() }}">
                 <!-- Контент по умолчанию, обрезка длинного текста с многоточием -->
-                <div class="controls-Grid__cell_{{(gridColumn || itemData).config.textOverflow}}">
+                <div class="{{ (gridColumn || itemData).getTextOverflowClasses() }}">
                     <ws:partial template="{{(gridColumn || itemData).getCellContentRender()}}"
+                                title="{{ (gridColumn || itemData).getTextOverflowTitle() }}"
                                 value="{{(gridColumn || itemData).getDefaultDisplayValue()}}"
                                 searchValue="{{(gridColumn || itemData).getSearchValue()}}"
                                 scope="{{(gridColumn || itemData).config}}"/>

--- a/Controls/_grid/Render/EditArrowTemplate.wml
+++ b/Controls/_grid/Render/EditArrowTemplate.wml
@@ -1,8 +1,8 @@
 <div class="controls-Grid__editArrow-wrapper js-controls-ListView__visible-on-hoverFreeze">
       <div if="{{textOverflow}}" class="controls-Grid__editArrow-withTextOverflow"></div>
-      <div class="controls-Grid__editArrow-blur"></div>
+      <div class="controls-Grid__editArrow-blur controls-Grid__editArrow-blur_style-{{item.getStyle()}}_background"></div>
       <div on:click="_onEditArrowClick(item)"
-           class="controls-Grid__editArrow">
+           class="controls-Grid__editArrow controls-Grid__editArrow_style-{{item.getStyle()}}_background">
            <svg class="controls-Grid__editArrow-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M9,9.94l-6,6v-2l4-4-4-4v-2Zm5,0-6,6v-2l4-4-4-4v-2Z"/></svg>
       </div>
 </div>

--- a/Controls/_grid/display/Cell.ts
+++ b/Controls/_grid/display/Cell.ts
@@ -292,12 +292,6 @@ export default class Cell<T extends Model, TOwner extends Row<T>> extends mixin<
 
         contentClasses += this._getContentAlignClasses();
 
-        // todo Чтобы работало многоточие - нужна ещё одна обертка над contentTemplate. Задача пересекается с настройкой
-        //      шаблона колонки (например, cursor на демо CellNoClickable)
-        if (this._$column.textOverflow) {
-            contentClasses += ` controls-Grid__cell_${this._$column.textOverflow}`;
-        }
-
         if (this._$isHiddenForLadder) {
             contentClasses += ' controls-Grid__row-cell__content_hiddenForLadder';
         }

--- a/Controls/_grid/display/DataCell.ts
+++ b/Controls/_grid/display/DataCell.ts
@@ -185,7 +185,8 @@ export default class DataCell<T extends Model, TOwner extends DataRow<T>> extend
     getTextOverflowClasses(): string {
         let classes =  `controls-Grid__cell_${this.config.textOverflow || 'none'} `;
 
-        // платформенный textOverflow работает только при использовании платформенного contentTemplate
+        // Для правильного отображения стрелки редактирования рядом с текстом, который
+        // обрезается нужно повесить на контейнер с этим текстом специальные CSS классы
         if (this.config.textOverflow && this.shouldDisplayEditArrow(null)) {
             classes += `controls-Grid__editArrow-cellContent controls-Grid__editArrow-overflow-${this.config.textOverflow}`;
         }

--- a/Controls/_grid/display/DataCell.ts
+++ b/Controls/_grid/display/DataCell.ts
@@ -93,7 +93,7 @@ export default class DataCell<T extends Model, TOwner extends DataRow<T>> extend
     }
 
     // region Аспект "Рендер"
-    getDefaultDisplayValue(): T {
+    getDefaultDisplayValue(): string | number {
         const itemModel = this._$owner.getContents();
         if (itemModel instanceof Record) {
             return itemModel.get(this.getDisplayProperty());
@@ -176,6 +176,26 @@ export default class DataCell<T extends Model, TOwner extends DataRow<T>> extend
             return false;
         }
         return this._$owner.editArrowIsVisible(this._$owner.getContents());
+    }
+
+    // endregion
+
+    // region Аспект "Обрезка текста по многоточию"
+
+    getTextOverflowClasses(): string {
+        let classes =  `controls-Grid__cell_${this.config.textOverflow || 'none'} `;
+
+        // платформенный textOverflow работает только при использовании платформенного contentTemplate
+        if (this.config.textOverflow && this.shouldDisplayEditArrow(null)) {
+            classes += `controls-Grid__editArrow-cellContent controls-Grid__editArrow-overflow-${this.config.textOverflow}`;
+        }
+        return classes;
+    }
+
+    getTextOverflowTitle(): string | number {
+        return this.config.textOverflow &&
+               !this.config.template &&
+               !this.config.tooltipProperty ? this.getDefaultDisplayValue() : '';
     }
 
     // endregion

--- a/Controls/_treeGrid/render/grid/Item.wml
+++ b/Controls/_treeGrid/render/grid/Item.wml
@@ -97,7 +97,7 @@
            'showItemActionsOnHover': showItemActionsOnHover
        }) }}">
          <ws:for data="column in (item || itemData).getColumns()">
-            <Controls.scroll:StickyHeader position="topbottom"
+            <Controls.scroll:StickyHeader position="{{ (item || itemData).getStickyHeaderPosition() }}"
                                           mode="{{ (item || itemData).getStickyHeaderMode() }}"
                                           shadowVisibility="{{column.shadowVisibility || 'lastVisible'}}"
                                           backgroundStyle="{{ backgroundStyle }}"

--- a/tests/ControlsUnit/grid_clean/Display/DataCell/isEditing.test.ts
+++ b/tests/ControlsUnit/grid_clean/Display/DataCell/isEditing.test.ts
@@ -1,8 +1,8 @@
 import { assert } from 'chai';
-import { GridDataCell, GridDataRow } from 'Controls/grid';
-import {CssClassesAssert as cAssert} from './../../CustomAsserts';
+import { GridDataCell } from 'Controls/grid';
+import {CssClassesAssert as cAssert} from './../../../CustomAsserts';
 
-describe('Controls/grid_clean/Display/DataCell', () => {
+describe('Controls/grid_clean/Display/DataCell/isEditing', () => {
     beforeEach(() => {
     });
 

--- a/tests/ControlsUnit/grid_clean/Display/DataCell/textOverflow.test.ts
+++ b/tests/ControlsUnit/grid_clean/Display/DataCell/textOverflow.test.ts
@@ -1,0 +1,91 @@
+import { assert } from 'chai';
+import { GridDataCell } from 'Controls/grid';
+import { CssClassesAssert as cAssert } from './../../../CustomAsserts';
+
+describe('Controls/grid_clean/Display/DataCell/isEditing', () => {
+    let editArrowIsVisible = false;
+
+    const mockedOwner = {
+        getHoverBackgroundStyle: () => 'default',
+        isDragged: () => false,
+        hasItemActionsSeparatedCell: () => false,
+        getTopPadding: () => 'default',
+        getBottomPadding: () => 'default',
+        getLeftPadding: () => 'default',
+        getRightPadding: () => 'default',
+        getEditingConfig: () => ({
+            mode: 'cell'
+        }),
+        getColumnIndex: () => 0,
+        getColumnsCount: () => 0,
+        getMultiSelectVisibility: () => 'hidden',
+        editArrowIsVisible: () => editArrowIsVisible,
+        getDefaultDisplayValue: () => 'value'
+    };
+
+    describe('getTextOverflowClasses', () => {
+
+        it('should add correct classes when textOverflow', () => {
+            const cell = new GridDataCell({
+                owner: mockedOwner,
+                column: {displayProperty: 'key', textOverflow: 'ellipsis'}
+            });
+            cAssert.include(cell.getTextOverflowClasses(), ['controls-Grid__cell_ellipsis']);
+        });
+
+        it('should add correct classes when not textOverflow', () => {
+            const cell = new GridDataCell({
+                owner: mockedOwner,
+                column: {displayProperty: 'key'}
+            });
+            cAssert.notInclude(cell.getTextOverflowClasses(), ['controls-Grid__cell_ellipsis']);
+        });
+
+        it('should add classes for editArrow placing when textOverflow and editArrow', () => {
+            editArrowIsVisible = true;
+            const cell = new GridDataCell({
+                owner: mockedOwner,
+                column: {displayProperty: 'key', textOverflow: 'ellipsis'}
+            });
+            cAssert.include(cell.getTextOverflowClasses(), [
+                'controls-Grid__editArrow-cellContent',
+                'controls-Grid__editArrow-overflow-ellipsis'
+            ]);
+        });
+
+        it('should not add classes for editArrow placing when textOverflow and not editArrow', () => {
+            const cell = new GridDataCell({
+                owner: mockedOwner,
+                column: {displayProperty: 'key', textOverflow: 'ellipsis'}
+            });
+            cAssert.notInclude(cell.getTextOverflowClasses(), [
+                'controls-Grid__editArrow-cellContent',
+                'controls-Grid__editArrow-overflow-ellipsis'
+            ]);
+        });
+    });
+
+    describe('getTextOverflowTitle', () => {
+        it('should return title when textOverflow and not custom template and not tooltipProperty', () => {
+            const cell = new GridDataCell({
+                owner: mockedOwner,
+                column: {displayProperty: 'key', textOverflow: 'ellipsis'}
+            });
+            assert.isTrue(cell.getTextOverflowTitle());
+        });
+        it('should not return title when textOverflow and custom template', () => {
+            const cell = new GridDataCell({
+                owner: mockedOwner,
+                column: {displayProperty: 'key', textOverflow: 'ellipsis', template: {}}
+            });
+            assert.isFalse(cell.getTextOverflowTitle());
+        });
+        it('should not return title when textOverflow and tooltipProperty', () => {
+            const cell = new GridDataCell({
+                owner: mockedOwner,
+                column: {displayProperty: 'key', textOverflow: 'ellipsis', tooltipProperty: 'tooltip'}
+            });
+            assert.isFalse(cell.getTextOverflowTitle());
+        });
+    });
+});

--- a/tests/ControlsUnit/grid_clean/Display/DataCell/textOverflow.test.ts
+++ b/tests/ControlsUnit/grid_clean/Display/DataCell/textOverflow.test.ts
@@ -2,8 +2,8 @@ import { assert } from 'chai';
 import { GridDataCell } from 'Controls/grid';
 import { CssClassesAssert as cAssert } from './../../../CustomAsserts';
 
-describe('Controls/grid_clean/Display/DataCell/isEditing', () => {
-    let editArrowIsVisible = false;
+describe('Controls/grid_clean/Display/DataCell/textOverflow', () => {
+    let editArrowIsVisible: boolean;
 
     const mockedOwner = {
         getHoverBackgroundStyle: () => 'default',
@@ -20,8 +20,13 @@ describe('Controls/grid_clean/Display/DataCell/isEditing', () => {
         getColumnsCount: () => 0,
         getMultiSelectVisibility: () => 'hidden',
         editArrowIsVisible: () => editArrowIsVisible,
-        getDefaultDisplayValue: () => 'value'
+        getDefaultDisplayValue: () => 'value',
+        getContents: () => ({ key: 'key'}),
     };
+
+    beforeEach(() => {
+        editArrowIsVisible = false;
+    })
 
     describe('getTextOverflowClasses', () => {
 
@@ -71,21 +76,21 @@ describe('Controls/grid_clean/Display/DataCell/isEditing', () => {
                 owner: mockedOwner,
                 column: {displayProperty: 'key', textOverflow: 'ellipsis'}
             });
-            assert.isTrue(cell.getTextOverflowTitle());
+            assert.equal('key', cell.getTextOverflowTitle());
         });
         it('should not return title when textOverflow and custom template', () => {
             const cell = new GridDataCell({
                 owner: mockedOwner,
                 column: {displayProperty: 'key', textOverflow: 'ellipsis', template: {}}
             });
-            assert.isFalse(cell.getTextOverflowTitle());
+            assert.isEmpty(cell.getTextOverflowTitle());
         });
         it('should not return title when textOverflow and tooltipProperty', () => {
             const cell = new GridDataCell({
                 owner: mockedOwner,
                 column: {displayProperty: 'key', textOverflow: 'ellipsis', tooltipProperty: 'tooltip'}
             });
-            assert.isFalse(cell.getTextOverflowTitle());
+            assert.isEmpty(cell.getTextOverflowTitle());
         });
     });
 });


### PR DESCRIPTION
https://online.sbis.ru/doc/4f608c37-3b16-41f6-8f08-8452538c079d  Шеврон в дереве (демо)
Удалили демку, по которой должны писать тесты
Нужно дать аналог в рабочем состоянии или вернуть старую демку (см. диалог)
Тесты в плане на март у автотестеров
Демо:
http://usd-comp175.corp.tensor.ru:777/Controls-demo/app/Controls-demo%2FList%2FTree%2FEditArrow
ФР: в демке ничего нет, предложили 2 варианта, один не работает в другом косяк
http://usd-comp175.corp.tensor.ru:777/Controls-demo/app/Controls-demo%2FtreeGridNew%2FEditArrow%2FBase%2FIndex
http://usd-comp175.corp.tensor.ru:777/Controls-demo/app/Controls-demo%2FtreeGridNew%2FEditArrow%2FWithColumnTemplate%2FIndex
ОР: есть демка либо аналог в рабочем сотосянии