### PR TITLE
Документ №1181711550 от 2021-04-15 Лихачев А.В.

### DIFF
--- a/Controls-demo/gridNew/Footer/SeparatedFooter/Index.ts
+++ b/Controls-demo/gridNew/Footer/SeparatedFooter/Index.ts
@@ -3,12 +3,18 @@ import * as Template from 'wml!Controls-demo/gridNew/Footer/SeparatedFooter/Sepa
 import {Memory} from 'Types/source';
 import {getCountriesStats} from '../../DemoHelpers/DataCatalog';
 import { IColumn } from 'Controls/grid';
+import {IItemAction} from "Controls/_itemActions/interface/IItemAction";
+import {
+    getActionsForContacts as getItemActions,
+    getMoreActions
+} from "Controls-demo/list_new/DemoHelpers/ItemActionsCatalog";
 
 export default class extends Control {
     protected _template: TemplateFunction = Template;
     protected _viewSource: Memory;
     protected _fullColumns: IColumn[] = getCountriesStats().getColumnsWithoutWidths();
     protected _smallColumns: IColumn[] = getCountriesStats().getColumnsWithoutWidths().slice(0, 4);
+    protected _itemActions: IItemAction[] = [...getItemActions(), ...getMoreActions()];
 
     protected _beforeMount(): void {
         this._smallColumns[0].width = '30px';

--- a/Controls-demo/gridNew/Footer/SeparatedFooter/SeparatedFooter.wml
+++ b/Controls-demo/gridNew/Footer/SeparatedFooter/SeparatedFooter.wml
@@ -4,7 +4,9 @@
             <Controls.grid:View
                     keyProperty="id"
                     source="{{_viewSource}}"
-                    columns="{{_smallColumns}}">
+                    columns="{{_smallColumns}}"
+                    itemActions="{{_itemActions}}"
+                    itemActionsPosition="outside">
                 <ws:footerTemplate>
                     <div class="controlsDemo__footer__separatedFooter__content">Старый способ установки подвала</div>
                 </ws:footerTemplate>
@@ -16,7 +18,9 @@
                     keyProperty="id"
                     source="{{_viewSource}}"
                     multiSelectVisibility="visible"
-                    columns="{{_smallColumns}}">
+                    columns="{{_smallColumns}}"
+                    itemActions="{{_itemActions}}"
+                    itemActionsPosition="outside">
                 <ws:footerTemplate>
                     <div class="controlsDemo__footer__separatedFooter__content">Старый способ установки подвала</div>
                 </ws:footerTemplate>
@@ -31,7 +35,9 @@
                 <Controls.grid:View
                         keyProperty="id"
                         source="{{_viewSource}}"
-                        columns="{{_smallColumns}}">
+                        columns="{{_smallColumns}}"
+                        itemActions="{{_itemActions}}"
+                        itemActionsPosition="outside">
                 </Controls.grid:View>
             </div>
 
@@ -40,7 +46,9 @@
                         keyProperty="id"
                         source="{{_viewSource}}"
                         multiSelectVisibility="visible"
-                        columns="{{_smallColumns}}">
+                        columns="{{_smallColumns}}"
+                        itemActions="{{_itemActions}}"
+                        itemActionsPosition="outside">
                 </Controls.grid:View>
             </div>
         </div>
@@ -51,6 +59,8 @@
             <Controls.grid:View
                     keyProperty="id"
                     source="{{_viewSource}}"
+                    itemActions="{{_itemActions}}"
+                    itemActionsPosition="outside"
                     columns="{{_smallColumns}}">
                 <ws:footerTemplate>
                     <div class="controlsDemo__footer__separatedFooter__content">Новый способ установки подвала. Подвал растянут</div>
@@ -63,7 +73,9 @@
                     keyProperty="id"
                     source="{{_viewSource}}"
                     multiSelectVisibility="visible"
-                    columns="{{_smallColumns}}">
+                    columns="{{_smallColumns}}"
+                    itemActions="{{_itemActions}}"
+                    itemActionsPosition="outside">
                 <ws:footerTemplate>
                     <div class="controlsDemo__footer__separatedFooter__content">Новый способ установки подвала. Подвал растянут</div>
                 </ws:footerTemplate>
@@ -76,7 +88,9 @@
             <Controls.grid:View
                     keyProperty="id"
                     source="{{_viewSource}}"
-                    columns="{{_fullColumns}}">
+                    columns="{{_fullColumns}}"
+                    itemActions="{{_itemActions}}"
+                    itemActionsPosition="outside">
                 <ws:footer>
                     <ws:Array>
                         <ws:Object/>
@@ -105,7 +119,9 @@
                     keyProperty="id"
                     source="{{_viewSource}}"
                     multiSelectVisibility="visible"
-                    columns="{{_fullColumns}}">
+                    columns="{{_fullColumns}}"
+                    itemActions="{{_itemActions}}"
+                    itemActionsPosition="outside">
                 <ws:footer>
                     <ws:Array>
                         <ws:Object/>

--- a/Controls/_grid/display/FooterCell.ts
+++ b/Controls/_grid/display/FooterCell.ts
@@ -1,13 +1,13 @@
 import FooterRow from './FooterRow';
-import Cell, {IOptions as IBaseCellOptions} from './Cell';
+import Cell, {IOptions as ICellOptions, IOptions as IBaseCellOptions} from './Cell';
+
+export interface IOptions<T> extends ICellOptions<T> {
+    shouldAddFooterPadding: boolean;
+}
 
 class FooterCell<T> extends Cell<T, FooterRow<T>> {
     protected readonly _defaultCellTemplate: string = 'Controls/grid:FooterColumnTemplate';
     protected _$shouldAddFooterPadding: boolean;
-
-    constructor(options: IBaseCellOptions<T>) {
-        super(options);
-    }
 
     //region Аспект "Стилевое оформление"
     getWrapperClasses(theme: string,

--- a/Controls/_grid/display/FooterCell.ts
+++ b/Controls/_grid/display/FooterCell.ts
@@ -3,6 +3,11 @@ import Cell, {IOptions as IBaseCellOptions} from './Cell';
 
 class FooterCell<T> extends Cell<T, FooterRow<T>> {
     protected readonly _defaultCellTemplate: string = 'Controls/grid:FooterColumnTemplate';
+    protected _$shouldAddFooterPadding: boolean;
+
+    constructor(options: IBaseCellOptions<T>) {
+        super(options);
+    }
 
     //region Аспект "Стилевое оформление"
     getWrapperClasses(theme: string,
@@ -17,7 +22,7 @@ class FooterCell<T> extends Cell<T, FooterRow<T>> {
             wrapperClasses += ` ${this._getColumnScrollWrapperClasses(theme)}`;
         }
 
-        if (this.getOwner().getActionsTemplateConfig()?.itemActionsPosition === 'outside') {
+        if (this._$shouldAddFooterPadding) {
             wrapperClasses += ' controls-GridView__footer__itemActionsV_outside';
         }
 
@@ -42,6 +47,7 @@ class FooterCell<T> extends Cell<T, FooterRow<T>> {
 
 Object.assign(FooterCell.prototype, {
     '[Controls/_display/grid/FooterCell]': true,
+    _$shouldAddFooterPadding: false,
     _moduleName: 'Controls/grid:GridFooterCell',
     _instancePrefix: 'grid-footer-cell-'
 });

--- a/Controls/_grid/display/FooterRow.ts
+++ b/Controls/_grid/display/FooterRow.ts
@@ -2,13 +2,18 @@ import {TemplateFunction} from 'UI/Base';
 import {isEqual} from 'Types/object';
 import {IColumn, TColumns} from 'Controls/interface';
 import {IItemActionsTemplateConfig} from 'Controls/display';
-import Row from './Row';
+import Row, {IOptions} from './Row';
 import FooterCell from 'Controls/_grid/display/FooterCell';
 import {TColspanCallbackResult} from 'Controls/_grid/display/mixins/Grid';
 
 export default class FooterRow<T> extends Row<string> {
     private _hasMoreData: boolean;
     private _actionsTemplateConfig: IItemActionsTemplateConfig;
+    protected _$shouldAddFooterPadding: boolean;
+
+    constructor(options?: IOptions<T>) {
+        super(options);
+    }
 
     getContents(): string {
         return 'footer';
@@ -47,6 +52,7 @@ export default class FooterRow<T> extends Row<string> {
         super._initializeColumns({
             shouldAddStickyLadderCells: !this._$rowTemplate,
             addEmptyCellsForStickyLadder: true,
+            shouldAddFooterPadding: this._$shouldAddFooterPadding,
             extensionCellsConstructors: {
                 stickyLadderCell: FooterCell,
                 multiSelectCell: this.getColumnsFactory({column: {}})
@@ -68,6 +74,7 @@ export default class FooterRow<T> extends Row<string> {
 
 Object.assign(FooterRow.prototype, {
     '[Controls/_display/grid/FooterRow]': true,
+    _$shouldAddFooterPadding: false,
     _moduleName: 'Controls/display:GridFooterRow',
     _instancePrefix: 'grid-footer-row-',
     _cellModule: 'Controls/grid:GridFooterCell'

--- a/Controls/_grid/display/FooterRow.ts
+++ b/Controls/_grid/display/FooterRow.ts
@@ -2,18 +2,14 @@ import {TemplateFunction} from 'UI/Base';
 import {isEqual} from 'Types/object';
 import {IColumn, TColumns} from 'Controls/interface';
 import {IItemActionsTemplateConfig} from 'Controls/display';
-import Row, {IOptions} from './Row';
-import FooterCell from 'Controls/_grid/display/FooterCell';
+import Row from './Row';
+import FooterCell, {IOptions as IFooterCellOptions} from 'Controls/_grid/display/FooterCell';
 import {TColspanCallbackResult} from 'Controls/_grid/display/mixins/Grid';
 
 export default class FooterRow<T> extends Row<string> {
     private _hasMoreData: boolean;
     private _actionsTemplateConfig: IItemActionsTemplateConfig;
     protected _$shouldAddFooterPadding: boolean;
-
-    constructor(options?: IOptions<T>) {
-        super(options);
-    }
 
     getContents(): string {
         return 'footer';
@@ -52,7 +48,6 @@ export default class FooterRow<T> extends Row<string> {
         super._initializeColumns({
             shouldAddStickyLadderCells: !this._$rowTemplate,
             addEmptyCellsForStickyLadder: true,
-            shouldAddFooterPadding: this._$shouldAddFooterPadding,
             extensionCellsConstructors: {
                 stickyLadderCell: FooterCell,
                 multiSelectCell: this.getColumnsFactory({column: {}})
@@ -67,6 +62,13 @@ export default class FooterRow<T> extends Row<string> {
         if (typeof column.startColumn === 'number' && typeof column.endColumn === 'number') {
             return column.endColumn - column.startColumn;
         }
+    }
+
+    protected _getColumnFactoryParams(column: IColumn, columnIndex: number): Partial<IFooterCellOptions<T>> {
+        return {
+            ...super._getColumnFactoryParams(column, columnIndex),
+            shouldAddFooterPadding: this._$shouldAddFooterPadding
+        };
     }
 
     //endregion

--- a/Controls/_grid/display/mixins/Grid.ts
+++ b/Controls/_grid/display/mixins/Grid.ts
@@ -403,7 +403,8 @@ export default abstract class Grid<S, T extends GridRowMixin<S>> {
             rowTemplate: options.footerTemplate,
             rowTemplateOptions: {},
             backgroundStyle: options.backgroundStyle,
-            columnSeparatorSize: options.columnSeparatorSize
+            columnSeparatorSize: options.columnSeparatorSize,
+            shouldAddFooterPadding: options.itemActionsPosition === 'outside'
         });
     }
 


### PR DESCRIPTION
https://online.sbis.ru/doc/b8c4e538-ee38-4839-884b-bb205d271131  Расширяется нижняя часть панели при наведении
Как повторить:
1. Авторизоваться на https://pre-test-online.sbis.ru/ (lisa_alisa / qazwsx123)
https://pre-test-online.sbis.ru/auth/?sbis_logs_auth=eyJsb2dpbiI6ICJsaXNhX2FsaXNhIiwgInBhc3MiOiAicWF6d3N4MTIzIn0=
2. Бизнес / Склад / вкладка Склады / перейти в начальные остатки по любой организации
3. Сохранить несколько партий по одной номенклатуре / переоткрыть диалог / навести на нижнюю часть панели
ФР:  расширилось
ОР:  сразу грузится в нужной ширине + поправить расстояние от партии до текста "Всего", см макет
http://axure.tensor.ru/sklad/%D1%81%D0%BA%D0%BB%D0%B0%D0%B4.html
Страница: Каталог
Логин: енотский123 Пароль: Енотский123Енотский123
Зайти под пользователем
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36
Версия:
online-inside_21.2100 (ver 21.2100) - 1116.153 (15.04.2021 - 08:11:40)
Platforma 21.2000 - 709 (14.04.2021 - 20:02:41)
WS 21.2000 - 1049 (15.04.2021 - 06:51:00)
Types 21.2000 - 1049 (15.04.2021 - 06:51:00)
CONTROLS 21.2000 - 1049 (15.04.2021 - 06:51:00)
SDK 21.2000 - 1357 (15.04.2021 - 07:38:56)
DISTRIBUTION: ext
GenerateDate: 15.04.2021 - 10:25:56
StableSDK
autoerror_sbislogs 15.04.2021