### PR TITLE
Документ №1181809585 от 2021-04-26 Зубарева Г.В.

### DIFF
--- a/Controls/_treeGrid/display/TreeGridNodeFooterRow.ts
+++ b/Controls/_treeGrid/display/TreeGridNodeFooterRow.ts
@@ -76,7 +76,7 @@ export default class TreeGridNodeFooterRow extends TreeGridDataRow<null> {
     }
 
     getItemClasses(): string {
-        return 'controls-Grid__row controls-TreeGrid__nodeFooter';
+        return 'controls-ListView__itemV controls-Grid__row controls-TreeGrid__nodeFooter';
     }
 
     getExpanderPaddingClasses(tmplExpanderSize?: string, theme: string = 'default'): string {

--- a/tests/ControlsUnit/treeGrid/display/TreeGridNodeFooterRow.test.ts
+++ b/tests/ControlsUnit/treeGrid/display/TreeGridNodeFooterRow.test.ts
@@ -96,7 +96,7 @@ describe('Controls/_treeGrid/display/TreeGridNodeFooterRow', () => {
    });
 
    it('.getItemClasses()', () => {
-      CssClassesAssert.isSame(nodeFooterRow.getItemClasses(), 'controls-Grid__row controls-TreeGrid__nodeFooter');
+      CssClassesAssert.isSame(nodeFooterRow.getItemClasses(), 'controls-ListView__itemV controls-Grid__row controls-TreeGrid__nodeFooter');
    });
 
    it('.getExpanderPaddingClasses()', () => {


### PR DESCRIPTION
https://online.sbis.ru/doc/f357bd7c-a9a7-47a2-b0e4-a5db4a6ffa63  Календарь бухгалтера. Всплывающее окно операции по событию отображается в углу экрана
Как повторить:  
Учет/Бухгалтерия/Отчеты
ввести в строку поиска - для редакции
прогрузить немного список вверх
нажать сменить ответственного у события над разделителем - датой
ФР:  
окно смены ответственного в углу
повторяется в хроме, сафари, так же с другими окнами (например, редактировать комментарий)
ОР:  
окно около события
Страница: Отчеты
Логин: dermann1 Пароль:   DerMann123
UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36
Версия:
online-inside_21.2100 (ver 21.2100) - 1266 (26.04.2021 - 20:14:56)
Platforma 21.2100 - 3 (26.04.2021 - 11:58:26)
WS 21.2100 - 11 (26.04.2021 - 19:10:38)
Types 21.2100 - 11 (26.04.2021 - 19:10:38)
CONTROLS 21.2100 - 11 (26.04.2021 - 19:10:38)
SDK 21.2100 - 11 (26.04.2021 - 19:58:47)
DISTRIBUTION: ext
GenerateDate: 26.04.2021 - 20:14:56
autoerror_sbislogs 26.04.2021