### PR TITLE
Документ №1182863614 от 2021-08-20 Сучкова К.С.

### DIFF
--- a/Controls-demo/gridNew/Header/HeaderVisibility/HeaderVisibility.wml
+++ b/Controls-demo/gridNew/Header/HeaderVisibility/HeaderVisibility.wml
@@ -11,7 +11,7 @@
         <Router.router:Reference attr:class="controls-text-label"
                                  state="/Controls-demo/app/:app"
                                  app="{{ 'Controls-demo/gridNew/Header/HeaderVisibility/DefaultAndResult/Index' }}">
-            <a href="{{content.href}}">Заголовок колонок не отображается + не отображается результат</a>
+            <a href="{{content.href}}">Заголовок колонок не отображается + отображается результат</a>
         </Router.router:Reference>
         <Controls-demo.gridNew.Header.HeaderVisibility.DefaultAndResult.Index/>
     </div>

--- a/Controls-demo/gridNew/Header/HeaderVisibility/HeaderVisibility.wml
+++ b/Controls-demo/gridNew/Header/HeaderVisibility/HeaderVisibility.wml
@@ -28,7 +28,7 @@
         <Router.router:Reference attr:class="controls-text-label"
                                  state="/Controls-demo/app/:app"
                                  app="{{ 'Controls-demo/gridNew/Header/HeaderVisibility/VisibleAndResult/Index' }}">
-            <a href="{{content.href}}">Заголовок колонок отображается + не отображается результат</a>
+            <a href="{{content.href}}">Заголовок колонок отображается + отображается результат</a>
         </Router.router:Reference>
         <Controls-demo.gridNew.Header.HeaderVisibility.VisibleAndResult.Index/>
     </div>

--- a/Controls/_grid/display/interface/IGridControl.ts
+++ b/Controls/_grid/display/interface/IGridControl.ts
@@ -509,7 +509,7 @@ export interface IGridControl extends IList {
  * @typedef {String} Controls/_grid/display/interface/IGridControl/ResultsVisibility
  * @description Допустимые значения для опции {@link resultsVisibility}.
  * @variant hasdata Отображается при наличии более 1 элемента в таблице.
- * @variant visible Отображается при наличии хотя бы 1 элемента в таблице.
+ * @variant visible Отображается всегда, вне зависимости от количества элементов в таблице.
  * @variant hidden Строка итогов скрыта.
  */
 

--- a/Controls/_grid/display/mixins/Grid.ts
+++ b/Controls/_grid/display/mixins/Grid.ts
@@ -428,11 +428,11 @@ export default abstract class Grid<S extends Model = Model, T extends GridRowMix
     }
 
     protected _hasItemsToCreateResults(): boolean {
-        return this.getCollectionCount() > (this._$resultsVisibility === 'visible' ? 0 : 1);
+        return this.getCollectionCount() > 1;
     }
 
     protected _resultsIsVisible(): boolean {
-        return !!this._$resultsPosition && this._$resultsVisibility !== 'hidden' && this._hasItemsToCreateResults();
+        return !!this._$resultsPosition && this._$resultsVisibility !== 'hidden' && (this._$resultsVisibility === 'visible' || this._hasItemsToCreateResults());
     }
 
     protected _initializeHeader(options: IOptions): void {

--- a/Controls/_searchBreadcrumbsGrid/display/SearchGridCollection.ts
+++ b/Controls/_searchBreadcrumbsGrid/display/SearchGridCollection.ts
@@ -110,7 +110,7 @@ export default
    }
 
    protected _hasItemsToCreateResults(): boolean {
-      return this.getCollectionCount() > (this._$resultsVisibility === 'visible' ? 0 : 1);
+      return this.getCollectionCount() > 1;
    }
 
    protected _getItemsFactory(): ItemsFactory<T> {

--- a/Controls/_treeGrid/display/TreeGridCollection.ts
+++ b/Controls/_treeGrid/display/TreeGridCollection.ts
@@ -334,8 +334,12 @@ export default class TreeGridCollection<
     // endregion itemsFactoryResolver
 
     protected _hasItemsToCreateResults(): boolean {
-        const rootItems = this.getChildrenByRecordSet(this.getRoot().getContents());
-        return rootItems.length > (this._$resultsVisibility === 'visible' ? 0 : 1);
+        let rootItems = this.getChildrenByRecordSet(this.getRoot().getContents());
+        // Если единственный узел в списке - группа, показываем строку итогов в зависимости от наличия его дочерних узлов
+        if (rootItems.length === 1 && this._$nodeTypeProperty && rootItems[0].get(this._$nodeTypeProperty) === 'group') {
+            return this.getChildrenByRecordSet(rootItems[0]).length > 1;
+        }
+        return rootItems.length > 1;
     }
 
     protected _initializeFooter(options: ITreeGridOptions): TreeGridFooterRow {

--- a/tests/ControlsUnit/treeGrid_clean/Display/Grid/getResults.test.ts
+++ b/tests/ControlsUnit/treeGrid_clean/Display/Grid/getResults.test.ts
@@ -23,28 +23,9 @@ describe('Controls/treeGrid_clean/Display/Grid/getResults', () => {
 
     describe('_resultsIsVisible', () => {
 
-        it('resultsVisibility=visible, should not create results when root contains no items', () => {
-            rawData = [];
-            const treeGridCollection = new TreeGridCollection({
-                collection: new RecordSet({
-                    rawData,
-                    keyProperty: 'key'
-                }),
-                resultsPosition: 'top',
-                keyProperty: 'key',
-                parentProperty: 'parent',
-                nodeProperty: 'type',
-                resultsVisibility: 'visible',
-                multiSelectVisibility: 'visible',
-                columns: [{}],
-                expandedItems: [ null ],
-                root: null
-            });
-
-            assert.notExists(treeGridCollection.getResults());
-        });
-
         it('resultsVisibility=hasdata, should not create results when root contains single item', () => {
+            // При наличии в корне единственного узла (даже если он развернут и у него есть дочерние элементы) - не
+            // должны создаваться results.
             const treeGridCollection = new TreeGridCollection({
                 collection: new RecordSet({
                     rawData,
@@ -65,10 +46,34 @@ describe('Controls/treeGrid_clean/Display/Grid/getResults', () => {
             assert.notExists(treeGridCollection.getResults());
         });
 
-        it('resultsVisibility=visible, should create results when root contains single item', () => {
+        it('resultsVisibility=hasdata, Should create results when root contains single groupNode item', () => {
+            // При наличии в корне единственного узла в виде группы если у него есть дочерние элементы
+            // должны создаваться results.
+            rawData[0].nodeType = 'group';
             const treeGridCollection = new TreeGridCollection({
                 collection: new RecordSet({
                     rawData,
+                    keyProperty: 'key'
+                }),
+                resultsPosition: 'top',
+                keyProperty: 'key',
+                parentProperty: 'parent',
+                nodeProperty: 'type',
+                resultsVisibility: 'hasdata',
+                multiSelectVisibility: 'visible',
+                columns: [{}],
+                expandedItems: [ null ],
+                root: null,
+                nodeTypeProperty: 'nodeType'
+            });
+
+            assert.exists(treeGridCollection.getResults());
+        });
+
+        it('resultsVisibility=visible, should create results when root contains no items', () => {
+            const treeGridCollection = new TreeGridCollection({
+                collection: new RecordSet({
+                    [],
                     keyProperty: 'key'
                 }),
                 resultsPosition: 'top',
@@ -85,5 +90,6 @@ describe('Controls/treeGrid_clean/Display/Grid/getResults', () => {
 
             assert.exists(treeGridCollection.getResults());
         });
+
     });
 });

--- a/tests/ControlsUnit/treeGrid_clean/Display/Grid/getResults.test.ts
+++ b/tests/ControlsUnit/treeGrid_clean/Display/Grid/getResults.test.ts
@@ -17,7 +17,7 @@ describe('Controls/treeGrid_clean/Display/Grid/getResults', () => {
         rawData = [
             { key: 1, parent: null, type: true },
             { key: 2, parent: 1, type: true },
-            { key: 3, parent: 2, type: null }
+            { key: 3, parent: 1, type: null }
         ];
     });
 

--- a/tests/ControlsUnit/treeGrid_clean/Display/Grid/getResults.test.ts
+++ b/tests/ControlsUnit/treeGrid_clean/Display/Grid/getResults.test.ts
@@ -73,7 +73,7 @@ describe('Controls/treeGrid_clean/Display/Grid/getResults', () => {
         it('resultsVisibility=visible, should create results when root contains no items', () => {
             const treeGridCollection = new TreeGridCollection({
                 collection: new RecordSet({
-                    [],
+                    rawData: [],
                     keyProperty: 'key'
                 }),
                 resultsPosition: 'top',


### PR DESCRIPTION
https://online.sbis.ru/doc/fc5b4817-4d65-44c7-b778-1413cc904afb Неправильное поведение resultsVisibility=visible
Статистика отправок УБ. Пропадает шапка на панели статистики, когда по поиску нет результатов
Как повторить:
упб/исходящие
клац кнопка вызова статистики
в поле поиска ввести несуществующие данные
ФР: шапка с полем поиска и статистикой по отправкам пропадает
ОР: шапка не пропадает, заглушка под шапкой
Страница: Исходящие УБ
Логин: убадмин Пароль: й1ц2у3к4е5н6
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36
Версия:
online-inside_21.4100 (ver 21.4100) - 878 (20.08.2021 - 08:00:01)
Platforma 21.4100 - 119 (19.08.2021 - 20:40:10)
WS 21.4100 - 348 (19.08.2021 - 08:34:50)
Types 21.4100 - 348 (19.08.2021 - 08:34:50)
CONTROLS 21.4100 - 356 (19.08.2021 - 20:53:28)
SDK 21.4100 - 390 (19.08.2021 - 22:06:03)
DISTRIBUTION: ext
GenerateDate: 20.08.2021 - 08:00:01
autoerror_sbislogs 20.08.2021