### PR TITLE
Документ №1182873431 от 2021-08-21 Хорошунов Е.Т.

### DIFF
--- a/Controls/_grid/display/mixins/Grid.ts
+++ b/Controls/_grid/display/mixins/Grid.ts
@@ -401,6 +401,7 @@ export default abstract class Grid<S, T extends GridRowMixin<S>> {
     setResultsVisibility(resultsVisibility: TResultsVisibility): void {
         if (this._$resultsVisibility !== resultsVisibility) {
             this._$resultsVisibility = resultsVisibility;
+            this._$results = null;
             this._nextVersion();
         }
     }

--- a/tests/ControlsUnit/grid_clean/Display/Collection.test.ts
+++ b/tests/ControlsUnit/grid_clean/Display/Collection.test.ts
@@ -179,6 +179,26 @@ describe('Controls/grid_clean/Display/Collection', () => {
                 assert.exists(gridCollection.getResults());
             });
         });
+        describe('resultsVisibility', () => {
+            it('setResultsVisibility resets results object', () => {
+                const gridCollection = new GridCollection({
+                    collection: [],
+                    keyProperty: 'key',
+                    columns: [{
+                        displayProperty: 'id',
+                        resultTemplate: () => 'result'
+                    }],
+                    resultsPosition: 'top',
+                    resultsVisibility: 'visible'
+                });
+
+                assert.exists(gridCollection.getResults());
+
+                gridCollection.setResultsVisibility('hasdata');
+
+                assert.notExists(gridCollection.getResults());
+            });
+        });
         describe('emptyTemplateColumns', () => {
             it('Initialize with emptyTemplateColumns', () => {
                 const emptyColumnsConfig = [


### PR DESCRIPTION
https://online.sbis.ru/doc/c0bbcbb7-92ba-4aec-9c35-de88f00bbbd4 Ошибка CONTROL ERROR:  Первый аргумент undefined имеет не поддерживаемый тип при сворачивании разделов
test-online.sbis.ru Балаган/Балаган1234
Шаги:
1. Главная Бизнес - отчет Продажи по сотрудникам
2. Построить отчет с детализацией Сотрудник - Номенклатура - По дням
3. На боковой панели нажать кнопку "развернуть разделы"
4. Снова нажать кнопку разворота разделов
ФР: Во время сворачивания в итогах появляются нули + ошибка в консоли
ОР: без ошибок
online-inside_21.4100 (ver 21.4100) - 893 (21.08.2021 - 00:00:01)
Platforma 21.4100 - 121 (20.08.2021 - 20:16:54)
WS 21.4100 - 360 (20.08.2021 - 12:16:19)
Types 21.4100 - 360 (20.08.2021 - 12:16:19)
CONTROLS 21.4100 - 365 (20.08.2021 - 23:08:51)
SDK 21.4100 - 399 (20.08.2021 - 23:49:49)
DISTRIBUTION: ext
GenerateDate: 21.08.2021 - 00:00:01