### PR TITLE
Документ №1183607412 от 2021-11-01 Репина Н.А.

### DIFF
--- a/Controls/_listTemplates/ImageDisplay/ImageDisplayContainer.ts
+++ b/Controls/_listTemplates/ImageDisplay/ImageDisplayContainer.ts
@@ -11,6 +11,7 @@ import {object} from 'Types/util';
 import {Object as EventObject} from 'Env/Event';
 import {Model} from 'Types/entity';
 import {TreeItem} from 'Controls/display';
+import {Direction} from 'Controls/interface';
 
 export interface IImageDisplayContainerOptions extends IControlOptions {
     itemsReadyCallback: (items: RecordSet) => void;
@@ -109,12 +110,20 @@ export default class ImageDisplayContainer extends Control<IImageDisplayContaine
         }
     }
 
-    private _updateDisplayImage(items, imageProperty, isResetState) {
-        if (imageProperty) {
-            if (isResetState) {
-                this._hasItemWithImage = ImageDisplayContainer._hasImage(items, imageProperty);
-            } else if (!this._hasItemWithImage) {
-                this._hasItemWithImage = ImageDisplayContainer._hasImage(items, imageProperty);
+    /**
+     * Обновляем состояние hasItemWithImage.
+     * Если текущее значение false, но в новых загруженных элементах вдруг стало true, нужно актуализировать.
+     * @param items RecordSet, в котором мы ищем картинку.
+     * @param imageProperty Свойство записи, в котором содержится картинка.
+     * @param isResetState Флаг, что данные перезагружаются (например, после reload, reloadItem,
+     * при первичной установке данных и при смене imageProperty).
+     * @private
+     */
+    private _updateDisplayImage(items: RecordSet, imageProperty: string, isResetState: boolean): void {
+        if (imageProperty && (isResetState || !this._hasItemWithImage)) {
+            const hasItemWithImage = ImageDisplayContainer._hasImage(items, imageProperty);
+            if (hasItemWithImage) {
+                this._hasItemWithImage = hasItemWithImage;
             }
         }
     }
@@ -153,7 +162,7 @@ export default class ImageDisplayContainer extends Control<IImageDisplayContaine
         }
     }
 
-    private _dataLoadCallback(items: RecordSet, direction): void {
+    private _dataLoadCallback(items: RecordSet, direction: Direction): void {
         if (!this._items) {
             this._items = items;
         }
@@ -170,8 +179,9 @@ export default class ImageDisplayContainer extends Control<IImageDisplayContaine
                                     item: Model,
                                     index: number,
                                     properties?: object): void {
-        // Изменение элемента, поменяли _imageProperty в записи в RecordSet
-        if (this._options.imageProperty && this._options.imageProperty in properties) {
+        // Изменение элемента, поменяли _imageProperty в записи в RecordSet.
+        if (this._options.imageProperty && typeof properties === 'object' &&
+            this._options.imageProperty in properties) {
             this._updateDisplayImage(this._items, this._options.imageProperty, false);
         }
     }


### PR DESCRIPTION
https://online.sbis.ru/doc/49294d26-158f-4fbc-924e-e6a28cdaa647 Перестают отображаться картинки в реестре после редактирования номенклатуры
Как повторить: 
Ночь/Ночь123
Каталог, Провалиться в раздел
открыть карточку, изменить
сохранить
ФР: 
реестр перестроился - стал без фото
ОР: 
не перестраивается, отображается согласно настройкам
Страница: Каталог
Логин: ночь Пароль:   
UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36
Версия:
online-inside_21.6100 (ver 21.6100) - 691 (01.11.2021 - 12:00:02)
Platforma 21.6100 - 59 (01.11.2021 - 10:05:25)
WS 21.6100 - 150 (01.11.2021 - 07:01:01)
Types 21.6100 - 150 (01.11.2021 - 07:01:01)
CONTROLS 21.6100 - 152 (01.11.2021 - 10:41:28)
SDK 21.6100 - 149 (01.11.2021 - 11:43:23)
DISTRIBUTION: ext
GenerateDate: 01.11.2021 - 12:00:02
autoerror_sbislogs 01.11.2021