### PR TITLE
Документ №1183896841 от 2021-11-26 Калинина М.В.

### DIFF
--- a/Controls/_grid/GridView.ts
+++ b/Controls/_grid/GridView.ts
@@ -313,7 +313,7 @@ const GridView = ListView.extend([ColumnScrollViewMixin], {
         let classes = `controls_list_theme-${options.theme} ${this._getColumnScrollWrapperClasses(options)}`;
         // Если нужно отобразить пустое представление, растягиваем grid на всю высоту
         if (options.needShowEmptyTemplate) {
-            classes += ' controls-GridView__gridWrapper_empty';
+            classes += ' controls-Grid__empty_gridWrapper';
         }
         return classes;
     },

--- a/Controls/_grid/GridView.ts
+++ b/Controls/_grid/GridView.ts
@@ -310,13 +310,23 @@ const GridView = ListView.extend([ColumnScrollViewMixin], {
     },
 
     _getGridViewWrapperClasses(options: IGridOptions): string {
-        return `controls_list_theme-${options.theme} ${this._getColumnScrollWrapperClasses(options)}`;
+        let classes = `controls_list_theme-${options.theme} ${this._getColumnScrollWrapperClasses(options)}`;
+        // Опция удалена в 22.1000. Если нужно отобразить пустое представление, растягиваем grid на всю высоту
+        if (options.task1183896841 && options.needShowEmptyTemplate) {
+            classes += ' controls-GridView__gridWrapper_empty';
+        }
+        return classes;
     },
 
     _getGridViewClasses(options: IGridOptions, columnScrollPartName?: 'fixed' | 'scrollable'): string {
         let classes = `controls-Grid controls-Grid_${options.style}`;
         if (GridLadderUtil.isSupportLadder(options.ladderProperties)) {
             classes += ` controls-Grid_support-ladder ${this._ladderOffsetSelector}`;
+        }
+
+        // Опция удалена в 22.1000. Если нужно отобразить пустое представление, растягиваем grid на всю высоту
+        if (options.task1183896841 && options.needShowEmptyTemplate) {
+            classes += ' controls-Grid__empty';
         }
 
         // Удалено в 22.1000. Быстрый фикс неправильной высоты результатов, чтобы не протягивать

--- a/Controls/_grid/GridView.ts
+++ b/Controls/_grid/GridView.ts
@@ -311,8 +311,8 @@ const GridView = ListView.extend([ColumnScrollViewMixin], {
 
     _getGridViewWrapperClasses(options: IGridOptions): string {
         let classes = `controls_list_theme-${options.theme} ${this._getColumnScrollWrapperClasses(options)}`;
-        // Опция удалена в 22.1000. Если нужно отобразить пустое представление, растягиваем grid на всю высоту
-        if (options.task1183896841 && options.needShowEmptyTemplate) {
+        // Если нужно отобразить пустое представление, растягиваем grid на всю высоту
+        if (options.needShowEmptyTemplate) {
             classes += ' controls-GridView__gridWrapper_empty';
         }
         return classes;
@@ -324,8 +324,8 @@ const GridView = ListView.extend([ColumnScrollViewMixin], {
             classes += ` controls-Grid_support-ladder ${this._ladderOffsetSelector}`;
         }
 
-        // Опция удалена в 22.1000. Если нужно отобразить пустое представление, растягиваем grid на всю высоту
-        if (options.task1183896841 && options.needShowEmptyTemplate) {
+        // Если нужно отобразить пустое представление, растягиваем grid на всю высоту
+        if (options.needShowEmptyTemplate) {
             classes += ' controls-Grid__empty';
         }
 

--- a/Controls/_grid/Render/grid/GridView.wml
+++ b/Controls/_grid/Render/grid/GridView.wml
@@ -45,13 +45,6 @@
                     backgroundStyle="{{ _options.backgroundStyle || _options.style }}"
                     on:positionChanged="_onColumnScrollThumbPositionChanged()"
                     on:dragEnd="_onColumnScrollThumbDragEnd()"/>
-
-            <!-- Контрол строит наиболее полный набор колонок таблицы. Подробное описание в контроле. -->
-            <Controls.columnScroll:RelativeColumns
-                    if="{{ !_$columnScrollUseFakeRender }}"
-                    isFullGridSupport="{{ true }}"
-                    containersUpdatedCallback="{{ _relativeCellContainersUpdateCallback }}"
-                    viewColumns="{{ _getViewColumns(_options) }}"/>
         </ws:if>
 
         <!-- Items -->
@@ -99,6 +92,15 @@
                         style="{{ _options.style }}"
                         containerSize="{{ _$columnScrollEmptyViewMaxWidth }}"
                         backgroundStyle="{{ _options.backgroundStyle || _options.style }}"/>
+        </ws:if>
+
+        <!-- Контрол строит наиболее полный набор колонок таблицы. Подробное описание в контроле. -->
+        <ws:if data="{{ _options.columnScroll }}">
+            <Controls.columnScroll:RelativeColumns
+                    if="{{ !_$columnScrollUseFakeRender }}"
+                    isFullGridSupport="{{ true }}"
+                    containersUpdatedCallback="{{ _relativeCellContainersUpdateCallback }}"
+                    viewColumns="{{ _getViewColumns(_options) }}"/>
         </ws:if>
 
         <!--Bottom loading trigger-->

--- a/Controls/_grid/display/EmptyCell.ts
+++ b/Controls/_grid/display/EmptyCell.ts
@@ -26,6 +26,7 @@ class EmptyCell extends mixin<
 
         if (this._$isSingleColspanedCell && hasRowTemplate) {
             classes = columnScrollClasses;
+            classes += ' controls-GridView__emptyTemplate__contentWrapper';
         } else if (this.isMultiSelectColumn()) {
             classes = 'controls-GridView__emptyTemplate__checkBoxCell '
                 + 'controls-Grid__row-cell-editing '

--- a/Controls/_grid/display/EmptyCell.ts
+++ b/Controls/_grid/display/EmptyCell.ts
@@ -26,7 +26,7 @@ class EmptyCell extends mixin<
 
         if (this._$isSingleColspanedCell && hasRowTemplate) {
             classes = columnScrollClasses;
-            classes += ' controls-GridView__emptyTemplate__contentWrapper';
+            classes += ' controls-GridView__emptyTemplate__cell_wrapper';
         } else if (this.isMultiSelectColumn()) {
             classes = 'controls-GridView__emptyTemplate__checkBoxCell '
                 + 'controls-Grid__row-cell-editing '

--- a/Controls/_grid/styles/_Grid.less
+++ b/Controls/_grid/styles/_Grid.less
@@ -25,8 +25,7 @@
    height: 100%;
 }
 
-// Костыль удалён в 22.1000, вместе с опцией task1183896841
-.controls-Grid__empty .controls-GridView__emptyTemplate__contentWrapper {
+.controls-GridView__emptyTemplate__contentWrapper {
    display: flex;
    align-items: center;
 }

--- a/Controls/_grid/styles/_Grid.less
+++ b/Controls/_grid/styles/_Grid.less
@@ -20,6 +20,17 @@
    position: relative;
 }
 
+.controls-Grid__empty,
+.controls-GridView__gridWrapper_empty {
+   height: 100%;
+}
+
+// Костыль удалён в 22.1000, вместе с опцией task1183896841
+.controls-Grid__empty .controls-GridView__emptyTemplate__contentWrapper {
+   display: flex;
+   align-items: center;
+}
+
 .controls-GridView__emptyTemplate {
    display: contents;
 }

--- a/Controls/_grid/styles/_Grid.less
+++ b/Controls/_grid/styles/_Grid.less
@@ -21,7 +21,7 @@
 }
 
 .controls-Grid__empty,
-.controls-GridView__gridWrapper_empty {
+.controls-Grid__empty_gridWrapper {
    height: 100%;
 }
 


### PR DESCRIPTION
https://online.sbis.ru/doc/e6d05e96-586d-4c76-b508-84e09ba6b782  Сместилась заглушка в реестре Маркета при провале в пустую папку/безрезультатной фильтрации (на плитке/списке)
тест
кабинет123/кабинет1234
Повторить:
Бизнес/Маркет/Каталог/Здравоохранение/Калинина
Установить режим плитка/список
Открыть пустыю папку ПАРАМБА/ выставить критерии в фильтре чтобы отобразилась заглушка
ФР: заглушка сместилась (скрин)
ОР: нет, по центру
online-inside_21.6200 (ver 21.6200) - 256 (26.11.2021 - 08:00:02)
Platforma 21.6200 - 137 (25.11.2021 - 22:35:03)
WS 21.6200 - 262 (25.11.2021 - 07:01:01)
Types 21.6200 - 262 (25.11.2021 - 07:01:01)
CONTROLS 21.6200 - 274 (25.11.2021 - 21:56:17)
SDK 21.6200 - 352 (26.11.2021 - 01:03:59)
DISTRIBUTION: inside